### PR TITLE
Update Remix dependencies to support v1 release

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,0 @@
-//npm.remix.run/:_authToken=${REMIX_TOKEN}
-@remix-run:registry=https://npm.remix.run

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,9 +19,9 @@
         "@babel/preset-env": "^7.14.1",
         "@babel/preset-react": "^7.13.13",
         "@babel/preset-typescript": "^7.13.0",
-        "@remix-run/dev": "^0.20.1",
-        "@remix-run/node": "^0.20.1",
-        "@remix-run/react": "^0.20.1",
+        "@remix-run/dev": "^1.0.4",
+        "@remix-run/node": "^1.0.4",
+        "@remix-run/react": "^1.0.4",
         "@types/accept-language-parser": "^1.5.2",
         "@types/jest": "^26.0.23",
         "@types/lru-cache": "^5.1.1",
@@ -47,19 +47,19 @@
         "prettier": "^2.3.2",
         "react": "^17.0.2",
         "react-i18next": "^11.13.0",
-        "react-router-dom": "^6.0.0-beta.6",
-        "remix": "^0.19.3",
+        "react-router-dom": "^6.0.2",
+        "remix": "^1.0.4",
         "ts-node": "^9.1.1",
         "typescript": "^4.3.5"
       },
       "peerDependencies": {
-        "@remix-run/node": "^0.20.1",
-        "@remix-run/react": "^0.20.1",
+        "@remix-run/node": "^1.0.4",
+        "@remix-run/react": "^1.0.4",
         "i18next": "^21.3.3",
         "react": "^17.0.2",
         "react-i18next": "^11.13.0",
-        "react-router-dom": "^6.0.0-beta.6",
-        "remix": "^0.20.1"
+        "react-router-dom": "^6.0.2",
+        "remix": "^1.0.4"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -2655,14 +2655,14 @@
       }
     },
     "node_modules/@remix-run/dev": {
-      "version": "0.20.1",
-      "resolved": "https://npm.remix.run/download/@remix-run/dev/0.20.1/559aca9b6679ccdcc450d4ac3f05327dbc431767bbcc153cbf668a89f2c6b98e",
-      "integrity": "sha512-x9pSNxDhPm9xLHxvKO4NTron2nepuRn9myZSUB0neyZLChERcD9hoHssbLJzhSwrrjWxD/daP+i5gTRx9qc5FQ==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@remix-run/dev/-/dev-1.0.4.tgz",
+      "integrity": "sha512-d1oem1exDQFsght2HaJgR99dy9KoT6vE4sBR32id8oTP9GNbiUkyu/KbPaSY1gHAuys9Qi3Kae/04kK0RbJBFw==",
       "dev": true,
       "dependencies": {
         "cacache": "^15.0.5",
         "chokidar": "^3.5.1",
-        "esbuild": "0.11.16",
+        "esbuild": "0.13.14",
         "fs-extra": "^10.0.0",
         "lodash.debounce": "^4.0.8",
         "meow": "^7.1.1",
@@ -2678,23 +2678,13 @@
         "remix": "cli.js"
       }
     },
-    "node_modules/@remix-run/dev/node_modules/esbuild": {
-      "version": "0.11.16",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.11.16.tgz",
-      "integrity": "sha512-34ZWjo4ouvM5cDe7uRoM9GFuMyEmpH9fnVYmomvS1cq9ED9d/0ZG1r+p4P2VbX7ihjv36zA2SWTmP8Zmt/EANA==",
-      "dev": true,
-      "hasInstallScript": true,
-      "bin": {
-        "esbuild": "bin/esbuild"
-      }
-    },
     "node_modules/@remix-run/node": {
-      "version": "0.20.1",
-      "resolved": "https://npm.remix.run/download/@remix-run/node/0.20.1/79461ceb8a3c7e085fe9d16d770765774e2e5e4828c25e71940e11de990d8454",
-      "integrity": "sha512-8TIo283aU2MK3p8eOmssHyT0rdhb6Re1py0pQyVo+HsdqLC5LbKwAiuejLZMteLowDkbBjubF2ENxWJC6JDb5w==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@remix-run/node/-/node-1.0.4.tgz",
+      "integrity": "sha512-19fo8XQO1XqhCeHXP5Pp2n2b3XR2WqmfJqsAvlik/iAiQhH0ztOZwWFkB0KpX5wUMAXR1fdoZG+VXxeA2pYKxQ==",
       "dev": true,
       "dependencies": {
-        "@remix-run/server-runtime": "0.20.1",
+        "@remix-run/server-runtime": "1.0.4",
         "@types/node-fetch": "^2.5.12",
         "cookie-signature": "^1.1.0",
         "node-fetch": "^2.6.1",
@@ -2711,36 +2701,34 @@
       }
     },
     "node_modules/@remix-run/react": {
-      "version": "0.20.1",
-      "resolved": "https://npm.remix.run/download/@remix-run/react/0.20.1/857120293b653af53ea1a582fbb9b6453d2d10f8dbb09af517dd42d887c4eb58",
-      "integrity": "sha512-g6pqwEsrGLM0crhjP28AH28LCnYAl8OIREoXyQZ1nRy2/mhhsgOUMPYlQj5YEI4E3GuBsqpF/xJ8DHC/IKIrcg==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@remix-run/react/-/react-1.0.4.tgz",
+      "integrity": "sha512-0sZES5KEag91XFNAXdFgg0cvzGAozcSGQRuwG1QuSie7E9fT54ea+GUtvX+Hk816gNV3KXp0ZpYPXceqkZZzrw==",
       "dev": true,
       "dependencies": {
-        "history": "^5.0.0"
+        "react-router-dom": "^6.0.2"
       },
       "peerDependencies": {
         "react": ">=16.8",
-        "react-dom": ">=16.8",
-        "react-router-dom": "6.0.0-beta.8"
+        "react-dom": ">=16.8"
       }
     },
     "node_modules/@remix-run/server-runtime": {
-      "version": "0.20.1",
-      "resolved": "https://npm.remix.run/download/@remix-run/server-runtime/0.20.1/38925d5cd8fbb6808309d7b677dc50cd3bf0aeb97c8abee0f3c28bd5a9366a45",
-      "integrity": "sha512-WAugslFVdWaU4S6nXKAZQ99+KBYoaV2pu9Vk6guxBB3SzuU7ipunE1AYcOL7bM8tYpfSRmBTnSPE1xKBo5asTQ==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@remix-run/server-runtime/-/server-runtime-1.0.4.tgz",
+      "integrity": "sha512-dZL3qIuvd8ngT0L1ShNJY2Fz/J3iRYcMOl9FdskBGYVVwTMlHMTDqqilBJGlmuxd2/nUkPxLfpos0ZkQGr1tXg==",
       "dev": true,
       "dependencies": {
         "@types/cookie": "^0.4.0",
         "cookie": "^0.4.1",
-        "history": "^5.0.0",
         "jsesc": "^3.0.1",
+        "react-router-dom": "^6.0.2",
         "set-cookie-parser": "^2.4.8",
         "source-map": "^0.7.3"
       },
       "peerDependencies": {
         "react": ">=16.8",
-        "react-dom": ">=16.8",
-        "react-router-dom": "6.0.0-beta.8"
+        "react-dom": ">=16.8"
       }
     },
     "node_modules/@remix-run/server-runtime/node_modules/jsesc": {
@@ -5144,6 +5132,256 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/esbuild": {
+      "version": "0.13.14",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.13.14.tgz",
+      "integrity": "sha512-xu4D+1ji9x53ocuomcY+KOrwAnWzhBu/wTEjpdgZ8I1c8i5vboYIeigMdzgY1UowYBKa2vZgVgUB32bu7gkxeg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "optionalDependencies": {
+        "esbuild-android-arm64": "0.13.14",
+        "esbuild-darwin-64": "0.13.14",
+        "esbuild-darwin-arm64": "0.13.14",
+        "esbuild-freebsd-64": "0.13.14",
+        "esbuild-freebsd-arm64": "0.13.14",
+        "esbuild-linux-32": "0.13.14",
+        "esbuild-linux-64": "0.13.14",
+        "esbuild-linux-arm": "0.13.14",
+        "esbuild-linux-arm64": "0.13.14",
+        "esbuild-linux-mips64le": "0.13.14",
+        "esbuild-linux-ppc64le": "0.13.14",
+        "esbuild-netbsd-64": "0.13.14",
+        "esbuild-openbsd-64": "0.13.14",
+        "esbuild-sunos-64": "0.13.14",
+        "esbuild-windows-32": "0.13.14",
+        "esbuild-windows-64": "0.13.14",
+        "esbuild-windows-arm64": "0.13.14"
+      }
+    },
+    "node_modules/esbuild-android-arm64": {
+      "version": "0.13.14",
+      "resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.13.14.tgz",
+      "integrity": "sha512-Q+Xhfp827r+ma8/DJgpMRUbDZfefsk13oePFEXEIJ4gxFbNv5+vyiYXYuKm43/+++EJXpnaYmEnu4hAKbAWYbA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/esbuild-darwin-64": {
+      "version": "0.13.14",
+      "resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.13.14.tgz",
+      "integrity": "sha512-YmOhRns6QBNSjpVdTahi/yZ8dscx9ai7a6OY6z5ACgOuQuaQ2Qk2qgJ0/siZ6LgD0gJFMV8UINFV5oky5TFNQQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/esbuild-darwin-arm64": {
+      "version": "0.13.14",
+      "resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.13.14.tgz",
+      "integrity": "sha512-Lp00VTli2jqZghSa68fx3fEFCPsO1hK59RMo1PRap5RUjhf55OmaZTZYnCDI0FVlCtt+gBwX5qwFt4lc6tI1xg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/esbuild-freebsd-64": {
+      "version": "0.13.14",
+      "resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.13.14.tgz",
+      "integrity": "sha512-BKosI3jtvTfnmsCW37B1TyxMUjkRWKqopR0CE9AF2ratdpkxdR24Vpe3gLKNyWiZ7BE96/SO5/YfhbPUzY8wKw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/esbuild-freebsd-arm64": {
+      "version": "0.13.14",
+      "resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.13.14.tgz",
+      "integrity": "sha512-yd2uh0yf+fWv5114+SYTl4/1oDWtr4nN5Op+PGxAkMqHfYfLjFKpcxwCo/QOS/0NWqPVE8O41IYZlFhbEN2B8Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/esbuild-linux-32": {
+      "version": "0.13.14",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.13.14.tgz",
+      "integrity": "sha512-a8rOnS1oWSfkkYWXoD2yXNV4BdbDKA7PNVQ1klqkY9SoSApL7io66w5H44mTLsfyw7G6Z2vLlaLI2nz9MMAowA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/esbuild-linux-64": {
+      "version": "0.13.14",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.13.14.tgz",
+      "integrity": "sha512-yPZSoMs9W2MC3Dw+6kflKt5FfQm6Dicex9dGIr1OlHRsn3Hm7yGMUTctlkW53KknnZdOdcdd5upxvbxqymczVQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/esbuild-linux-arm": {
+      "version": "0.13.14",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.13.14.tgz",
+      "integrity": "sha512-8chZE4pkKRvJ/M/iwsNQ1KqsRg2RyU5eT/x2flNt/f8F2TVrDreR7I0HEeCR50wLla3B1C3wTIOzQBmjuc6uWg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/esbuild-linux-arm64": {
+      "version": "0.13.14",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.13.14.tgz",
+      "integrity": "sha512-Lvo391ln9PzC334e+jJ2S0Rt0cxP47eoH5gFyv/E8HhOnEJTvm7A+RRnMjjHnejELacTTfYgFGQYPjLsi/jObQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/esbuild-linux-mips64le": {
+      "version": "0.13.14",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.13.14.tgz",
+      "integrity": "sha512-MZhgxbmrWbpY3TOE029O6l5tokG9+Yoj2hW7vdit/d/VnmneqeGrSHADuDL6qXM8L5jaCiaivb4VhsyVCpdAbQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/esbuild-linux-ppc64le": {
+      "version": "0.13.14",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.13.14.tgz",
+      "integrity": "sha512-un7KMwS7fX1Un6BjfSZxTT8L5cV/8Uf4SAhM7WYy2XF8o8TI+uRxxD03svZnRNIPsN2J5cl6qV4n7Iwz+yhhVw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/esbuild-netbsd-64": {
+      "version": "0.13.14",
+      "resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.13.14.tgz",
+      "integrity": "sha512-5ekKx/YbOmmlTeNxBjh38Uh5TGn5C4uyqN17i67k18pS3J+U2hTVD7rCxcFcRS1AjNWumkVL3jWqYXadFwMS0Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "netbsd"
+      ]
+    },
+    "node_modules/esbuild-openbsd-64": {
+      "version": "0.13.14",
+      "resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.13.14.tgz",
+      "integrity": "sha512-9bzvwewHjct2Cv5XcVoE1yW5YTW12Sk838EYfA46abgnhxGoFSD1mFcaztp5HHC43AsF+hQxbSFG/RilONARUA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/esbuild-sunos-64": {
+      "version": "0.13.14",
+      "resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.13.14.tgz",
+      "integrity": "sha512-mjMrZB76M6FmoiTvj/RGWilrioR7gVwtFBRVugr9qLarXMIU1W/pQx+ieEOtflrW61xo8w1fcxyHsVVGRvoQ0w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "sunos"
+      ]
+    },
+    "node_modules/esbuild-windows-32": {
+      "version": "0.13.14",
+      "resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.13.14.tgz",
+      "integrity": "sha512-GZa6mrx2rgfbH/5uHg0Rdw50TuOKbdoKCpEBitzmG5tsXBdce+cOL+iFO5joZc6fDVCLW3Y6tjxmSXRk/v20Hg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/esbuild-windows-64": {
+      "version": "0.13.14",
+      "resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.13.14.tgz",
+      "integrity": "sha512-Lsgqah24bT7ClHjLp/Pj3A9wxjhIAJyWQcrOV4jqXAFikmrp2CspA8IkJgw7HFjx6QrJuhpcKVbCAe/xw0i2yw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/esbuild-windows-arm64": {
+      "version": "0.13.14",
+      "resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.13.14.tgz",
+      "integrity": "sha512-KP8FHVlWGhM7nzYtURsGnskXb/cBCPTfj0gOKfjKq2tHtYnhDZywsUG57nk7TKhhK0fL11LcejHG3LRW9RF/9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
     "node_modules/escalade": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
@@ -7041,9 +7279,9 @@
       }
     },
     "node_modules/history": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/history/-/history-5.0.1.tgz",
-      "integrity": "sha512-5qC/tFUKfVci5kzgRxZxN5Mf1CV8NmJx9ByaPX0YTLx5Vz3Svh7NYp6eA4CpDq4iA9D0C1t8BNIfvQIrUI3mVw==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/history/-/history-5.1.0.tgz",
+      "integrity": "sha512-zPuQgPacm2vH2xdORvGGz1wQMuHSIB56yNAy5FnLuwOwgSYyPKptJtcMm6Ev+hRGeS+GzhbmRacHzvlESbFwDg==",
       "dev": true,
       "dependencies": {
         "@babel/runtime": "^7.7.6"
@@ -12100,28 +12338,30 @@
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true
     },
-    "node_modules/react-router-dom": {
-      "version": "6.0.0-beta.8",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.0.0-beta.8.tgz",
-      "integrity": "sha512-WyiIc6EakJDCo6rUmb7VjCtOpEvm8+4V8CiJdmFPud0lppeNf37TNhTnDQszDbP2y29wBUGb94BOFU2X93uILA==",
+    "node_modules/react-router": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.0.2.tgz",
+      "integrity": "sha512-8/Wm3Ed8t7TuedXjAvV39+c8j0vwrI5qVsYqjFr5WkJjsJpEvNSoLRUbtqSEYzqaTUj1IV+sbPJxvO+accvU0Q==",
       "dev": true,
       "dependencies": {
-        "react-router": "6.0.0-beta.8"
+        "history": "^5.1.0"
       },
       "peerDependencies": {
-        "history": ">=5",
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
+        "react": ">=16.8"
       }
     },
-    "node_modules/react-router-dom/node_modules/react-router": {
-      "version": "6.0.0-beta.8",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.0.0-beta.8.tgz",
-      "integrity": "sha512-pn3j01FA44yWP5gaHvz3CMVjFnmg5NS/BQ5IIalY7jw2yEKgr+OHB1gxTorakpiMaPOXXbfyUt3t4yZ4UBwE5Q==",
+    "node_modules/react-router-dom": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.0.2.tgz",
+      "integrity": "sha512-cOpJ4B6raFutr0EG8O/M2fEoyQmwvZWomf1c6W2YXBZuFBx8oTk/zqjXghwScyhfrtnt0lANXV2182NQblRxFA==",
       "dev": true,
+      "dependencies": {
+        "history": "^5.1.0",
+        "react-router": "6.0.2"
+      },
       "peerDependencies": {
-        "history": ">=5",
-        "react": ">=16.8"
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
       }
     },
     "node_modules/read-package-json-fast": {
@@ -12387,9 +12627,9 @@
       }
     },
     "node_modules/remix": {
-      "version": "0.19.3",
-      "resolved": "https://registry.npmjs.org/remix/-/remix-0.19.3.tgz",
-      "integrity": "sha512-TbO1i8mohBsoymSNe+bXOTwNVNxdJim6Tx7XbWQXqujspyMaiPx2Nzh7vkGB5c4OZ136oHvgE5e+/4w5kUDSHg==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/remix/-/remix-1.0.4.tgz",
+      "integrity": "sha512-yjED3VIxmNn/gU1KjpUbAJ2LQnsXNbB1GDm5//Kq/Z1/Ba0W4JE6dFqoXdG0oHL6o+jQct9S020vXZVHQPKJ8A==",
       "dev": true,
       "dependencies": {
         "fs-extra": "^10.0.0"
@@ -16548,14 +16788,14 @@
       }
     },
     "@remix-run/dev": {
-      "version": "0.20.1",
-      "resolved": "https://npm.remix.run/download/@remix-run/dev/0.20.1/559aca9b6679ccdcc450d4ac3f05327dbc431767bbcc153cbf668a89f2c6b98e",
-      "integrity": "sha512-x9pSNxDhPm9xLHxvKO4NTron2nepuRn9myZSUB0neyZLChERcD9hoHssbLJzhSwrrjWxD/daP+i5gTRx9qc5FQ==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@remix-run/dev/-/dev-1.0.4.tgz",
+      "integrity": "sha512-d1oem1exDQFsght2HaJgR99dy9KoT6vE4sBR32id8oTP9GNbiUkyu/KbPaSY1gHAuys9Qi3Kae/04kK0RbJBFw==",
       "dev": true,
       "requires": {
         "cacache": "^15.0.5",
         "chokidar": "^3.5.1",
-        "esbuild": "0.11.16",
+        "esbuild": "0.13.14",
         "fs-extra": "^10.0.0",
         "lodash.debounce": "^4.0.8",
         "meow": "^7.1.1",
@@ -16566,23 +16806,15 @@
         "signal-exit": "^3.0.3",
         "ws": "^7.4.5",
         "xdm": "^2.0.0"
-      },
-      "dependencies": {
-        "esbuild": {
-          "version": "0.11.16",
-          "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.11.16.tgz",
-          "integrity": "sha512-34ZWjo4ouvM5cDe7uRoM9GFuMyEmpH9fnVYmomvS1cq9ED9d/0ZG1r+p4P2VbX7ihjv36zA2SWTmP8Zmt/EANA==",
-          "dev": true
-        }
       }
     },
     "@remix-run/node": {
-      "version": "0.20.1",
-      "resolved": "https://npm.remix.run/download/@remix-run/node/0.20.1/79461ceb8a3c7e085fe9d16d770765774e2e5e4828c25e71940e11de990d8454",
-      "integrity": "sha512-8TIo283aU2MK3p8eOmssHyT0rdhb6Re1py0pQyVo+HsdqLC5LbKwAiuejLZMteLowDkbBjubF2ENxWJC6JDb5w==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@remix-run/node/-/node-1.0.4.tgz",
+      "integrity": "sha512-19fo8XQO1XqhCeHXP5Pp2n2b3XR2WqmfJqsAvlik/iAiQhH0ztOZwWFkB0KpX5wUMAXR1fdoZG+VXxeA2pYKxQ==",
       "dev": true,
       "requires": {
-        "@remix-run/server-runtime": "0.20.1",
+        "@remix-run/server-runtime": "1.0.4",
         "@types/node-fetch": "^2.5.12",
         "cookie-signature": "^1.1.0",
         "node-fetch": "^2.6.1",
@@ -16598,24 +16830,24 @@
       }
     },
     "@remix-run/react": {
-      "version": "0.20.1",
-      "resolved": "https://npm.remix.run/download/@remix-run/react/0.20.1/857120293b653af53ea1a582fbb9b6453d2d10f8dbb09af517dd42d887c4eb58",
-      "integrity": "sha512-g6pqwEsrGLM0crhjP28AH28LCnYAl8OIREoXyQZ1nRy2/mhhsgOUMPYlQj5YEI4E3GuBsqpF/xJ8DHC/IKIrcg==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@remix-run/react/-/react-1.0.4.tgz",
+      "integrity": "sha512-0sZES5KEag91XFNAXdFgg0cvzGAozcSGQRuwG1QuSie7E9fT54ea+GUtvX+Hk816gNV3KXp0ZpYPXceqkZZzrw==",
       "dev": true,
       "requires": {
-        "history": "^5.0.0"
+        "react-router-dom": "^6.0.2"
       }
     },
     "@remix-run/server-runtime": {
-      "version": "0.20.1",
-      "resolved": "https://npm.remix.run/download/@remix-run/server-runtime/0.20.1/38925d5cd8fbb6808309d7b677dc50cd3bf0aeb97c8abee0f3c28bd5a9366a45",
-      "integrity": "sha512-WAugslFVdWaU4S6nXKAZQ99+KBYoaV2pu9Vk6guxBB3SzuU7ipunE1AYcOL7bM8tYpfSRmBTnSPE1xKBo5asTQ==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@remix-run/server-runtime/-/server-runtime-1.0.4.tgz",
+      "integrity": "sha512-dZL3qIuvd8ngT0L1ShNJY2Fz/J3iRYcMOl9FdskBGYVVwTMlHMTDqqilBJGlmuxd2/nUkPxLfpos0ZkQGr1tXg==",
       "dev": true,
       "requires": {
         "@types/cookie": "^0.4.0",
         "cookie": "^0.4.1",
-        "history": "^5.0.0",
         "jsesc": "^3.0.1",
+        "react-router-dom": "^6.0.2",
         "set-cookie-parser": "^2.4.8",
         "source-map": "^0.7.3"
       },
@@ -18488,6 +18720,150 @@
         "is-symbol": "^1.0.2"
       }
     },
+    "esbuild": {
+      "version": "0.13.14",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.13.14.tgz",
+      "integrity": "sha512-xu4D+1ji9x53ocuomcY+KOrwAnWzhBu/wTEjpdgZ8I1c8i5vboYIeigMdzgY1UowYBKa2vZgVgUB32bu7gkxeg==",
+      "dev": true,
+      "requires": {
+        "esbuild-android-arm64": "0.13.14",
+        "esbuild-darwin-64": "0.13.14",
+        "esbuild-darwin-arm64": "0.13.14",
+        "esbuild-freebsd-64": "0.13.14",
+        "esbuild-freebsd-arm64": "0.13.14",
+        "esbuild-linux-32": "0.13.14",
+        "esbuild-linux-64": "0.13.14",
+        "esbuild-linux-arm": "0.13.14",
+        "esbuild-linux-arm64": "0.13.14",
+        "esbuild-linux-mips64le": "0.13.14",
+        "esbuild-linux-ppc64le": "0.13.14",
+        "esbuild-netbsd-64": "0.13.14",
+        "esbuild-openbsd-64": "0.13.14",
+        "esbuild-sunos-64": "0.13.14",
+        "esbuild-windows-32": "0.13.14",
+        "esbuild-windows-64": "0.13.14",
+        "esbuild-windows-arm64": "0.13.14"
+      }
+    },
+    "esbuild-android-arm64": {
+      "version": "0.13.14",
+      "resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.13.14.tgz",
+      "integrity": "sha512-Q+Xhfp827r+ma8/DJgpMRUbDZfefsk13oePFEXEIJ4gxFbNv5+vyiYXYuKm43/+++EJXpnaYmEnu4hAKbAWYbA==",
+      "dev": true,
+      "optional": true
+    },
+    "esbuild-darwin-64": {
+      "version": "0.13.14",
+      "resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.13.14.tgz",
+      "integrity": "sha512-YmOhRns6QBNSjpVdTahi/yZ8dscx9ai7a6OY6z5ACgOuQuaQ2Qk2qgJ0/siZ6LgD0gJFMV8UINFV5oky5TFNQQ==",
+      "dev": true,
+      "optional": true
+    },
+    "esbuild-darwin-arm64": {
+      "version": "0.13.14",
+      "resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.13.14.tgz",
+      "integrity": "sha512-Lp00VTli2jqZghSa68fx3fEFCPsO1hK59RMo1PRap5RUjhf55OmaZTZYnCDI0FVlCtt+gBwX5qwFt4lc6tI1xg==",
+      "dev": true,
+      "optional": true
+    },
+    "esbuild-freebsd-64": {
+      "version": "0.13.14",
+      "resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.13.14.tgz",
+      "integrity": "sha512-BKosI3jtvTfnmsCW37B1TyxMUjkRWKqopR0CE9AF2ratdpkxdR24Vpe3gLKNyWiZ7BE96/SO5/YfhbPUzY8wKw==",
+      "dev": true,
+      "optional": true
+    },
+    "esbuild-freebsd-arm64": {
+      "version": "0.13.14",
+      "resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.13.14.tgz",
+      "integrity": "sha512-yd2uh0yf+fWv5114+SYTl4/1oDWtr4nN5Op+PGxAkMqHfYfLjFKpcxwCo/QOS/0NWqPVE8O41IYZlFhbEN2B8Q==",
+      "dev": true,
+      "optional": true
+    },
+    "esbuild-linux-32": {
+      "version": "0.13.14",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.13.14.tgz",
+      "integrity": "sha512-a8rOnS1oWSfkkYWXoD2yXNV4BdbDKA7PNVQ1klqkY9SoSApL7io66w5H44mTLsfyw7G6Z2vLlaLI2nz9MMAowA==",
+      "dev": true,
+      "optional": true
+    },
+    "esbuild-linux-64": {
+      "version": "0.13.14",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.13.14.tgz",
+      "integrity": "sha512-yPZSoMs9W2MC3Dw+6kflKt5FfQm6Dicex9dGIr1OlHRsn3Hm7yGMUTctlkW53KknnZdOdcdd5upxvbxqymczVQ==",
+      "dev": true,
+      "optional": true
+    },
+    "esbuild-linux-arm": {
+      "version": "0.13.14",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.13.14.tgz",
+      "integrity": "sha512-8chZE4pkKRvJ/M/iwsNQ1KqsRg2RyU5eT/x2flNt/f8F2TVrDreR7I0HEeCR50wLla3B1C3wTIOzQBmjuc6uWg==",
+      "dev": true,
+      "optional": true
+    },
+    "esbuild-linux-arm64": {
+      "version": "0.13.14",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.13.14.tgz",
+      "integrity": "sha512-Lvo391ln9PzC334e+jJ2S0Rt0cxP47eoH5gFyv/E8HhOnEJTvm7A+RRnMjjHnejELacTTfYgFGQYPjLsi/jObQ==",
+      "dev": true,
+      "optional": true
+    },
+    "esbuild-linux-mips64le": {
+      "version": "0.13.14",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.13.14.tgz",
+      "integrity": "sha512-MZhgxbmrWbpY3TOE029O6l5tokG9+Yoj2hW7vdit/d/VnmneqeGrSHADuDL6qXM8L5jaCiaivb4VhsyVCpdAbQ==",
+      "dev": true,
+      "optional": true
+    },
+    "esbuild-linux-ppc64le": {
+      "version": "0.13.14",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.13.14.tgz",
+      "integrity": "sha512-un7KMwS7fX1Un6BjfSZxTT8L5cV/8Uf4SAhM7WYy2XF8o8TI+uRxxD03svZnRNIPsN2J5cl6qV4n7Iwz+yhhVw==",
+      "dev": true,
+      "optional": true
+    },
+    "esbuild-netbsd-64": {
+      "version": "0.13.14",
+      "resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.13.14.tgz",
+      "integrity": "sha512-5ekKx/YbOmmlTeNxBjh38Uh5TGn5C4uyqN17i67k18pS3J+U2hTVD7rCxcFcRS1AjNWumkVL3jWqYXadFwMS0Q==",
+      "dev": true,
+      "optional": true
+    },
+    "esbuild-openbsd-64": {
+      "version": "0.13.14",
+      "resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.13.14.tgz",
+      "integrity": "sha512-9bzvwewHjct2Cv5XcVoE1yW5YTW12Sk838EYfA46abgnhxGoFSD1mFcaztp5HHC43AsF+hQxbSFG/RilONARUA==",
+      "dev": true,
+      "optional": true
+    },
+    "esbuild-sunos-64": {
+      "version": "0.13.14",
+      "resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.13.14.tgz",
+      "integrity": "sha512-mjMrZB76M6FmoiTvj/RGWilrioR7gVwtFBRVugr9qLarXMIU1W/pQx+ieEOtflrW61xo8w1fcxyHsVVGRvoQ0w==",
+      "dev": true,
+      "optional": true
+    },
+    "esbuild-windows-32": {
+      "version": "0.13.14",
+      "resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.13.14.tgz",
+      "integrity": "sha512-GZa6mrx2rgfbH/5uHg0Rdw50TuOKbdoKCpEBitzmG5tsXBdce+cOL+iFO5joZc6fDVCLW3Y6tjxmSXRk/v20Hg==",
+      "dev": true,
+      "optional": true
+    },
+    "esbuild-windows-64": {
+      "version": "0.13.14",
+      "resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.13.14.tgz",
+      "integrity": "sha512-Lsgqah24bT7ClHjLp/Pj3A9wxjhIAJyWQcrOV4jqXAFikmrp2CspA8IkJgw7HFjx6QrJuhpcKVbCAe/xw0i2yw==",
+      "dev": true,
+      "optional": true
+    },
+    "esbuild-windows-arm64": {
+      "version": "0.13.14",
+      "resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.13.14.tgz",
+      "integrity": "sha512-KP8FHVlWGhM7nzYtURsGnskXb/cBCPTfj0gOKfjKq2tHtYnhDZywsUG57nk7TKhhK0fL11LcejHG3LRW9RF/9A==",
+      "dev": true,
+      "optional": true
+    },
     "escalade": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
@@ -19917,9 +20293,9 @@
       "dev": true
     },
     "history": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/history/-/history-5.0.1.tgz",
-      "integrity": "sha512-5qC/tFUKfVci5kzgRxZxN5Mf1CV8NmJx9ByaPX0YTLx5Vz3Svh7NYp6eA4CpDq4iA9D0C1t8BNIfvQIrUI3mVw==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/history/-/history-5.1.0.tgz",
+      "integrity": "sha512-zPuQgPacm2vH2xdORvGGz1wQMuHSIB56yNAy5FnLuwOwgSYyPKptJtcMm6Ev+hRGeS+GzhbmRacHzvlESbFwDg==",
       "dev": true,
       "requires": {
         "@babel/runtime": "^7.7.6"
@@ -23595,22 +23971,23 @@
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true
     },
-    "react-router-dom": {
-      "version": "6.0.0-beta.8",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.0.0-beta.8.tgz",
-      "integrity": "sha512-WyiIc6EakJDCo6rUmb7VjCtOpEvm8+4V8CiJdmFPud0lppeNf37TNhTnDQszDbP2y29wBUGb94BOFU2X93uILA==",
+    "react-router": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.0.2.tgz",
+      "integrity": "sha512-8/Wm3Ed8t7TuedXjAvV39+c8j0vwrI5qVsYqjFr5WkJjsJpEvNSoLRUbtqSEYzqaTUj1IV+sbPJxvO+accvU0Q==",
       "dev": true,
       "requires": {
-        "react-router": "6.0.0-beta.8"
-      },
-      "dependencies": {
-        "react-router": {
-          "version": "6.0.0-beta.8",
-          "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.0.0-beta.8.tgz",
-          "integrity": "sha512-pn3j01FA44yWP5gaHvz3CMVjFnmg5NS/BQ5IIalY7jw2yEKgr+OHB1gxTorakpiMaPOXXbfyUt3t4yZ4UBwE5Q==",
-          "dev": true,
-          "requires": {}
-        }
+        "history": "^5.1.0"
+      }
+    },
+    "react-router-dom": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.0.2.tgz",
+      "integrity": "sha512-cOpJ4B6raFutr0EG8O/M2fEoyQmwvZWomf1c6W2YXBZuFBx8oTk/zqjXghwScyhfrtnt0lANXV2182NQblRxFA==",
+      "dev": true,
+      "requires": {
+        "history": "^5.1.0",
+        "react-router": "6.0.2"
       }
     },
     "read-package-json-fast": {
@@ -23819,9 +24196,9 @@
       }
     },
     "remix": {
-      "version": "0.19.3",
-      "resolved": "https://registry.npmjs.org/remix/-/remix-0.19.3.tgz",
-      "integrity": "sha512-TbO1i8mohBsoymSNe+bXOTwNVNxdJim6Tx7XbWQXqujspyMaiPx2Nzh7vkGB5c4OZ136oHvgE5e+/4w5kUDSHg==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/remix/-/remix-1.0.4.tgz",
+      "integrity": "sha512-yjED3VIxmNn/gU1KjpUbAJ2LQnsXNbB1GDm5//Kq/Z1/Ba0W4JE6dFqoXdG0oHL6o+jQct9S020vXZVHQPKJ8A==",
       "dev": true,
       "requires": {
         "fs-extra": "^10.0.0"

--- a/package.json
+++ b/package.json
@@ -36,13 +36,13 @@
   },
   "homepage": "https://github.com/sergiodxa/remix-i18next#readme",
   "peerDependencies": {
-    "@remix-run/node": "^0.20.1",
-    "@remix-run/react": "^0.20.1",
+    "@remix-run/node": "^1.0.4",
+    "@remix-run/react": "^1.0.4",
     "i18next": "^21.3.3",
     "react": "^17.0.2",
     "react-i18next": "^11.13.0",
-    "react-router-dom": "^6.0.0-beta.6",
-    "remix": "^0.20.1"
+    "react-router-dom": "^6.0.2",
+    "remix": "^1.0.4"
   },
   "dependencies": {
     "accept-language-parser": "^1.5.0",
@@ -54,9 +54,9 @@
     "@babel/preset-env": "^7.14.1",
     "@babel/preset-react": "^7.13.13",
     "@babel/preset-typescript": "^7.13.0",
-    "@remix-run/dev": "^0.20.1",
-    "@remix-run/node": "^0.20.1",
-    "@remix-run/react": "^0.20.1",
+    "@remix-run/dev": "^1.0.4",
+    "@remix-run/node": "^1.0.4",
+    "@remix-run/react": "^1.0.4",
     "@types/accept-language-parser": "^1.5.2",
     "@types/jest": "^26.0.23",
     "@types/lru-cache": "^5.1.1",
@@ -82,8 +82,8 @@
     "prettier": "^2.3.2",
     "react": "^17.0.2",
     "react-i18next": "^11.13.0",
-    "react-router-dom": "^6.0.0-beta.6",
-    "remix": "^0.19.3",
+    "react-router-dom": "^6.0.2",
+    "remix": "^1.0.4",
     "ts-node": "^9.1.1",
     "typescript": "^4.3.5"
   }


### PR DESCRIPTION
## Things Done

- Updated the dev and peer dependencies for `remix` and `react-router-dom` to match the v1 release of Remix on Nov 22
- Removed the `.npmrc` since Remix is now a public package on NPM