### PR TITLE
Avoid react error when changing locale

### DIFF
--- a/src/react.tsx
+++ b/src/react.tsx
@@ -1,6 +1,13 @@
 import { useMatches } from "@remix-run/react";
 import { i18n } from "i18next";
-import { createContext, ReactNode, useContext, useMemo } from "react";
+import {
+  createContext,
+  ReactNode,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+} from "react";
 import { I18nextProvider } from "react-i18next";
 import useConsistentValue from "use-consistent-value";
 import { Language } from "./backend";
@@ -28,12 +35,20 @@ export function useRemixI18Next(locale: string) {
       )
   );
 
-  useMemo(() => {
+  const handleLocaleUpdate = useCallback(() => {
     i18next.changeLanguage(locale);
     for (let [namespace, messages] of Object.entries(namespaces)) {
       i18next.addResourceBundle(locale, namespace, messages);
     }
   }, [i18next, namespaces, locale]);
+
+  useMemo(() => {
+    handleLocaleUpdate();
+  }, []);
+
+  useEffect(() => {
+    handleLocaleUpdate();
+  }, [handleLocaleUpdate]);
 }
 
 interface RemixI18NextProvider {

--- a/src/react.tsx
+++ b/src/react.tsx
@@ -35,7 +35,7 @@ export function useRemixI18Next(locale: string) {
       )
   );
 
-  const handleLocaleUpdate = useCallback(() => {
+  let handleLocaleUpdate = useCallback(() => {
     i18next.changeLanguage(locale);
     for (let [namespace, messages] of Object.entries(namespaces)) {
       i18next.addResourceBundle(locale, namespace, messages);


### PR DESCRIPTION
I use `remix-i18next` with `i18next-locize-backend`.

Everything works properly except when changing the locale on the client for the first time I get this error:
<img width="1410" alt="CleanShot 2021-12-16 at 14 58 35@2x" src="https://user-images.githubusercontent.com/73319876/146385662-05708b8f-bcd1-4dcc-a1d9-91af41e60254.png">
Subsequent changes don't cause that error anymore.

I don't have a deep enough understanding to explain the error, but [I've found](https://flaviocopes.com/react-update-while-rendering-different-component/) that using `useEffect` in combination with `useMemo` fixes the issue.