### PR TITLE
Use defaultNS or "translation" 

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,7 +250,7 @@ export let loader: LoaderFunction = async ({ request }) => {
   return json({ title });
 };
 
-export let meta: MetaFunction = async ({ data }) => {
+export let meta: MetaFunction = ({ data }) => {
   return { title: data.title };
 };
 ```

--- a/README.md
+++ b/README.md
@@ -257,12 +257,12 @@ export let meta: MetaFunction = async ({ data }) => {
 
 The `getFixedT` function can be called using a combination of parameters:
 
-- `getFixedT(request)`: will use the request to get the locale and default the namespace to `common`
-- `getFixedT("es")`: will use the specified locale and default the namespace to `common`
-- `getFixedT(request, "namespace")` will use the request to get the locale and the specified namespace to get the translations.
-- `getFixedT("es", "namespace")` will use the specified locale and the specified namespace to get the translations.
-- `getFixedT(request, "common", { keySeparator: false })` will use the request to get the locale and the common namespace to get the translations, also use the options of the third argument to initialize the i18next instance.
-- `getFixedT("es", "common", { keySeparator: false })` will use the specified locale and the common namespace to get the translations, also use the options of the third argument to initialize the i18next instance.
+- `getFixedT(request)`: will use the request to get the locale and the `defaultNS` set in the config or `translation` (the [i18next default namespace](https://www.i18next.com/overview/configuration-options#languages-namespaces-resources))
+- `getFixedT("es")`: will use the specified `es` locale and the `defaultNS` set in config, or `translation` (the [i18next default namespace](https://www.i18next.com/overview/configuration-options#languages-namespaces-resources))
+- `getFixedT(request, "common")` will use the request to get the locale and the specified `common` namespace to get the translations.
+- `getFixedT("es", "common")` will use the specified `es` locale and the specified `common` namespace to get the translations.
+- `getFixedT(request, "common", { keySeparator: false })` will use the request to get the locale and the `common` namespace to get the translations, also use the options of the third argument to initialize the i18next instance.
+- `getFixedT("es", "common", { keySeparator: false })` will use the specified `es` locale and the `common` namespace to get the translations, also use the options of the third argument to initialize the i18next instance.
 
 If you always need to set the same i18next options, you can pass them to RemixI18Next when creating the new instance.
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -140,7 +140,7 @@ export class RemixI18Next {
   ) {
     // Make sure there's at least one namespace
     if (!namespaces || namespaces.length === 0) {
-      namespaces = "translation";
+      namespaces = this.options.i18next?.defaultNS || "translation";
     }
 
     let [instance, locale] = await Promise.all([


### PR DESCRIPTION
The README file states that "common" is the default namespace, but it's not, it's "translation" as set on [server.ts:143](https://github.com/sergiodxa/remix-i18next/blob/main/src/server.ts#L143).

The default namespace in i18next is "translation", so that convention should be adhered to.

However, if you set a defaultNS in your config (be it "common" or anything else), then that should be the fallback and it should not be hard-coded to "translation".

This PR fixes that issue by using the defaultNS (if set) and "translation" (if not), and also updates the README to reflect this change.

Also updated the README for MetaFunction which should not be async.