### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,7 +250,7 @@ export let loader: LoaderFunction = async ({ request }) => {
   return json({ title });
 };
 
-export let meta: MetaFunction = async ({ data }) => {
+export let meta: MetaFunction = ({ data }) => {
   return { title: data.title };
 };
 ```

--- a/README.md
+++ b/README.md
@@ -257,12 +257,12 @@ export let meta: MetaFunction = async ({ data }) => {
 
 The `getFixedT` function can be called using a combination of parameters:
 
-- `getFixedT(request)`: will use the request to get the locale and default the namespace to `common`
-- `getFixedT("es")`: will use the specified locale and default the namespace to `common`
-- `getFixedT(request, "namespace")` will use the request to get the locale and the specified namespace to get the translations.
-- `getFixedT("es", "namespace")` will use the specified locale and the specified namespace to get the translations.
-- `getFixedT(request, "common", { keySeparator: false })` will use the request to get the locale and the common namespace to get the translations, also use the options of the third argument to initialize the i18next instance.
-- `getFixedT("es", "common", { keySeparator: false })` will use the specified locale and the common namespace to get the translations, also use the options of the third argument to initialize the i18next instance.
+- `getFixedT(request)`: will use the request to get the locale and the `defaultNS` set in the config or `translation` (the [i18next default namespace](https://www.i18next.com/overview/configuration-options#languages-namespaces-resources))
+- `getFixedT("es")`: will use the specified `es` locale and the `defaultNS` set in config, or `translation` (the [i18next default namespace](https://www.i18next.com/overview/configuration-options#languages-namespaces-resources))
+- `getFixedT(request, "common")` will use the request to get the locale and the specified `common` namespace to get the translations.
+- `getFixedT("es", "common")` will use the specified `es` locale and the specified `common` namespace to get the translations.
+- `getFixedT(request, "common", { keySeparator: false })` will use the request to get the locale and the `common` namespace to get the translations, also use the options of the third argument to initialize the i18next instance.
+- `getFixedT("es", "common", { keySeparator: false })` will use the specified `es` locale and the `common` namespace to get the translations, also use the options of the third argument to initialize the i18next instance.
 
 If you always need to set the same i18next options, you can pass them to RemixI18Next when creating the new instance.
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ export default {
     // This is the list of languages your application supports
     supportedLngs: ['en', 'es'],
     // This is the language you want to use in case
-    // if the browser language is not in the supportedLngs
+    // if the user language is not in the supportedLngs
     fallbackLng: 'en',
     // The default namespace of i18next is "translation", but you can customize it here
     defaultNS: 'common',
@@ -53,7 +53,7 @@ And then create a file named `i18next.server.ts` with the following code:
 import Backend from 'i18next-fs-backend';
 import { resolve } from 'node:path';
 import { RemixI18Next } from 'remix-i18next';
-import i18n from './i18n'; // your i18n configuration file
+import i18n from '~/i18n'; // your i18n configuration file
 
 let i18next = new RemixI18Next({
   detection: {
@@ -208,7 +208,7 @@ export let loader: LoaderFunction = async ({ request }) => {
 };
 
 export let handle = {
-  // In the handle export, we scan add a i18n key with namespaces our route
+  // In the handle export, we can add a i18n key with namespaces our route
   // will need to load. This key can be a single string or an array of strings.
   // TIP: In most cases, you should set this to your defaultNS from your i18n config
   // or if you did not set one, set it to the i18next default namespace "translation"

--- a/README.md
+++ b/README.md
@@ -255,14 +255,7 @@ export let handle = {
   i18n: "home",
 };
 
-// Example 1: use the "home" namespace prefix
-export default function Prefix() {
-  let { t } = useTranslation();
-  return <h1>{t("home:title")}</h1>;
-}
-
-// Example 2: pass the "home" namespace, and not use a prefix
-export default function WithoutPrefix() {
+export default function Component() {
   let { t } = useTranslation("home");
   return <h1>{t("title")}</h1>;
 }

--- a/README.md
+++ b/README.md
@@ -21,31 +21,53 @@ npm install remix-i18next i18next react-i18next i18next-http-backend i18next-fs-
 
 ### Configuration
 
-Then create a `i18n.server.ts` file somewhere in your app and add the following code:
+First, set your [i18next configuration](https://www.i18next.com/overview/configuration-options).
+
+These two files can go somewhere in your app folder.
+
+For this example, we will create `app/i18n.ts`:
 
 ```ts
-import Backend from "i18next-fs-backend";
-import { resolve } from "node:path";
-import { RemixI18Next } from "remix-i18next";
-
-export let i18n = new RemixI18Next({
-  detection: {
+export default {
     // This is the list of languages your application supports
-    supportedLanguages: ["es", "en"],
-    // This is the language you want to use in case the user language is not
-    // listed above
-    fallbackLanguage: "en",
+    supportedLngs: ['en', 'es'],
+    // This is the language you want to use in case
+    // if the browser language is not in the supportedLngs
+    fallbackLng: 'en',
+    // The default namespace of i18next is "translation", but you can customize it here
+    defaultNS: 'common',
+    // Disabling suspense is recommended
+    react: {useSuspense: false},
+};
+```
+
+And then create a file named `i18next.server.ts` with the following code:
+
+```ts
+import Backend from 'i18next-fs-backend';
+import { resolve } from 'node:path';
+import { RemixI18Next } from 'remix-i18next';
+import i18n from './i18n'; // your i18n configuration file
+
+let i18next = new RemixI18Next({
+  detection: {
+    supportedLanguages: i18n.supportedLngs,
+    fallbackLanguage: i18n.fallbackLng,
   },
-  // This is the configuration for i18next used when translating messages server
-  // side only
+  // This is the configuration for i18next used
+  // when translating messages server-side only
   i18next: {
-    backend: { loadPath: resolve("./public/locales/{{lng}}/{{ns}}.json") },
+    backend: {
+      loadPath: resolve('./public/locales/{{lng}}/{{ns}}.json'),
+    },
   },
   // The backend you want to use to load the translations
   // Tip: You could pass `resources` to the `i18next` configuration and avoid
   // a backend here
   backend: Backend,
 });
+
+export default i18next;
 ```
 
 ### Client-side configuration
@@ -53,29 +75,26 @@ export let i18n = new RemixI18Next({
 Now in your `entry.client.tsx` replace the default code with this:
 
 ```tsx
-import { RemixBrowser } from "@remix-run/react";
-import i18next from "i18next";
-import LanguageDetector from "i18next-browser-languagedetector";
-import Backend from "i18next-http-backend";
-import { hydrate } from "react-dom";
-import { I18nextProvider, initReactI18next } from "react-i18next";
-import { getInitialNamespaces } from "remix-i18next";
+import { RemixBrowser } from '@remix-run/react';
+import i18next from 'i18next';
+import LanguageDetector from 'i18next-browser-languagedetector';
+import Backend from 'i18next-http-backend';
+import { hydrate } from 'react-dom';
+import { I18nextProvider, initReactI18next } from 'react-i18next';
+import { getInitialNamespaces } from 'remix-i18next';
+import i18n from './i18n'; // your i18n configuration file
 
 i18next
   .use(initReactI18next) // Tell i18next to use the react-i18next plugin
   .use(LanguageDetector) // Setup a client-side language detector
   .use(Backend) // Setup your backend
   .init({
-    // This is normal i18next config, except a few things
-    supportedLngs: ["es", "en"],
-    defaultNS: "common",
-    fallbackLng: "en",
-    // Disabling suspense is recommended
-    react: { useSuspense: false },
+    ...i18n, // spread the configuration
     // This function detects the namespaces your routes rendered while SSR use
-    // and pass them here to load the translations
     ns: getInitialNamespaces(),
-    backend: { loadPath: "/locales/{{lng}}/{{ns}}.json" },
+    backend: {
+      loadPath: '/locales/{{lng}}/{{ns}}.json',
+    },
     detection: {
       // Here only enable htmlTag detection, we'll detect the language only
       // server-side with remix-i18next, by using the `<html lang>` attribute
@@ -111,7 +130,8 @@ import Backend from "i18next-fs-backend";
 import { resolve } from "node:path";
 import { renderToString } from "react-dom/server";
 import { I18nextProvider, initReactI18next } from "react-i18next";
-import { i18n } from "./services/i18n.server";
+import i18next from "./i18next.server";
+import i18n from './i18n'; // your i18n configuration file
 
 export default async function handleRequest(
   request: Request,
@@ -132,14 +152,9 @@ export default async function handleRequest(
     .use(initReactI18next) // Tell our instance to use react-i18next
     .use(Backend) // Setup our backend
     .init({
-      // And configure i18next as usual
-      supportedLngs: ["es", "en"],
-      defaultNS: "common",
-      fallbackLng: "en",
-      // Disable suspense again here
-      react: { useSuspense: false },
+      ...i18n, // spread the configuration
       lng, // The locale we detected above
-      ns, // The namespaces the routes about to render want to use
+      ns, // The namespaces the routes about to render wants to use
       backend: {
         loadPath: resolve("./public/locales/{{lng}}/{{ns}}.json"),
       },
@@ -175,21 +190,23 @@ import {
   Scripts,
   ScrollRestoration,
 } from "@remix-run/react";
-import { i18n } from "~/i18n.server.ts";
 import { useChangeLanguage } from "remix-i18next";
 import { useTranslation } from "react-i18next";
+import i18next from "~/i18n.server.ts";
 
 type LoaderData = { locale: string };
 
 export let loader: LoaderFunction = async ({ request }) => {
-  let locale = await i18n.getLocale(request);
+  let locale = await i18next.getLocale(request);
   return json<LoaderData>({ locale });
 };
 
 export let handle = {
-  // In the handle export, we could add a i18n key with namespaces our route
+  // In the handle export, we scan add a i18n key with namespaces our route
   // will need to load. This key can be a single string or an array of strings.
-  i18n: ["translations", "root"],
+  // TIP: In most cases, you should set this to your defaultNS from your i18n config
+  // or if you did not set one, set it to the i18next default namespace "translation"
+  i18n: "translation",
 };
 
 export default function Root() {
@@ -221,17 +238,25 @@ export default function Root() {
 }
 ```
 
-Finally, in any route you want to translate you can do this:
+Finally, in any route you want to translate, you can use the `t()` function, as per the [i18next documentation](https://www.i18next.com/overview/api#t).
 
 ```tsx
 import { json, LoaderFunction } from "@remix-run/node";
 import { useTranslation } from "react-i18next";
 
+// This tells remix to load the "home" namespace
 export let handle = {
   i18n: "home",
 };
 
-export default function Component() {
+// Example 1: use the "home" namespace prefix
+export default function Prefix() {
+  let { t } = useTranslation();
+  return <h1>{t("home:title")}</h1>;
+}
+
+// Example 2: pass the "home" namespace, and not use a prefix
+export default function WithoutPrefix() {
   let { t } = useTranslation("home");
   return <h1>{t("title")}</h1>;
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -140,7 +140,7 @@ export class RemixI18Next {
   ) {
     // Make sure there's at least one namespace
     if (!namespaces || namespaces.length === 0) {
-      namespaces = "translation";
+      namespaces = this.options.i18next?.defaultNS || "translation";
     }
 
     let [instance, locale] = await Promise.all([


### PR DESCRIPTION
I have attempted to clarify the usage examples to make it easier to get up and running.

First, to avoid duplication of configuration in multiple places, I suggested creating a file with the i18next init configuration and spreading it in the other files. This makes it so you only have to update one place when you want to add languages, namespaces, etc.

I then updated the code example in the other files to use this new configuration file.

To ensure that the defaultNS is always included in every page, I updated the comment in the root file handle to explain that you should include the defaultNS from the configuration, or "translation" if you didn't set it.

I also provided links in various places to the relevant documentation in i18next.

Another reason to separate the configuration into its own file as I have (118n.ts) is if you add Storybook to your project, you'll want to import that same configuration there, as well. This could also be used in Jest, Cypress, etc. depending on the needs of the project.

Happy to get any feedback, rewrites, etc.