### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ let i18next = new RemixI18Next({
   // This is the configuration for i18next used
   // when translating messages server-side only
   i18next: {
+    ...i18n,
     backend: {
       loadPath: resolve('./public/locales/{{lng}}/{{ns}}.json'),
     },


### PR DESCRIPTION
Documented that you should spread your i18next config in the options since getFixedT will otherwise fall back to "translation" instead of the intended defaultNS. See https://github.com/sergiodxa/remix-i18next/blob/main/src/server.ts#L143