### PR TITLE
Fix/vercel headers fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -45,9 +45,9 @@
       "peerDependencies": {
         "@remix-run/react": "^1.0.0",
         "@remix-run/server-runtime": "^1.0.0",
-        "i18next": "^21.3.3 || ^22.0.3",
+        "i18next": "^22.0.3",
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
-        "react-i18next": "^11.13.0 || ^12.0.0"
+        "react-i18next": "^12.0.0"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/src/lib/get-headers.ts
+++ b/src/lib/get-headers.ts
@@ -1,12 +1,12 @@
 /**
  * Receives a Request or Headers objects.
- * If it's a Request returns the request.headers
- * If it's a Headers returns the object directly.
+ * If it's a Request returns the object directly
+ * If it's a Headers returns the request.headers
  */
 export function getHeaders(requestOrHeaders: Request | Headers): Headers {
-  if (requestOrHeaders instanceof Request) {
-    return requestOrHeaders.headers;
+  if (requestOrHeaders instanceof Headers) {
+    return requestOrHeaders;
   }
 
-  return requestOrHeaders;
+  return requestOrHeaders.headers;
 }


### PR DESCRIPTION
This should fix #117 using the solution from [gdomaradzki](https://github.com/gdomaradzki)

It reverts the logic of `getHeaders` function, and deployments to Vercel work correctly
