### PR TITLE
Add option to customize search parameter key

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -249,7 +249,9 @@ class LanguageDetector {
 
   private async fromSearchParams(request: Request): Promise<string | null> {
     let url = new URL(request.url);
-    if (!url.searchParams.has(this.options.searchParamKey ?? "lng")) return null;
+    if (!url.searchParams.has(this.options.searchParamKey ?? "lng")) {
+      return null;
+    }
     return this.fromSupported(
       url.searchParams.get(this.options.searchParamKey ?? "lng")
     );

--- a/src/server.ts
+++ b/src/server.ts
@@ -47,6 +47,13 @@ export interface LanguageDetectorOption {
    */
   sessionKey?: string;
   /**
+   * If you want to use search parameters for language detection and want to
+   * change the default key used to for the parameter name,
+   * you can pass the key here.
+   * @default "lng"
+   */
+  searchParamKey?: string;
+  /**
    * The order the library will use to detect the user preferred language.
    * By default the order is
    * - searchParams
@@ -242,8 +249,10 @@ class LanguageDetector {
 
   private async fromSearchParams(request: Request): Promise<string | null> {
     let url = new URL(request.url);
-    if (!url.searchParams.has("lng")) return null;
-    return this.fromSupported(url.searchParams.get("lng"));
+    if (!url.searchParams.has(this.options.searchParamKey ?? "lng")) return null;
+    return this.fromSupported(
+      url.searchParams.get(this.options.searchParamKey ?? "lng")
+    );
   }
 
   private async fromCookie(request: Request): Promise<string | null> {


### PR DESCRIPTION
This PR introduces a new field to `detection` object to allow for custom search parameter keys.

```ts
export const i18next = new RemixI18Next({
	detection: {
		order: ["searchParams", "header"],
                // Package will now look for the `?language=...` instead of the default `?lng=...`
                searchParamKey: "language",
	},
});
```