### PR TITLE
Fix package.json definition so remix can correctly resolve sub-dependcies

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,17 @@
     "./build/backend": false
   },
   "main": "./build/index.js",
+  "types": "./build/index.d.ts",
+  "jsnext:main": "./browser/index.js",
+  "module": "./browser/index.js",
+  "exports": {
+    "./package.json": "./package.json",
+    ".": {
+      "types": "./build/index.d.ts",
+      "import": "./browser/index.js",
+      "require": "./build/index.js"
+    }
+  },
   "scripts": {
     "build": "npm run build:browser && npm run build:main",
     "build:browser": "tsc --project tsconfig.json --module ESNext --outDir ./browser",


### PR DESCRIPTION
This is basically a straight port of the react-i18next package.json definitions. Fixes #107 when applied manually to my node_modules.