### PR TITLE
Support passing multiple `i18next` modules to `RemixI18Next`

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,10 +86,10 @@ let i18next = new RemixI18Next({
       loadPath: resolve("./public/locales/{{lng}}/{{ns}}.json"),
     },
   },
-  // The backend you want to use to load the translations
-  // Tip: You could pass `resources` to the `i18next` configuration and avoid
-  // a backend here
-  backend: Backend,
+  // The i18next plugins you want RemixI18next to use for `i18n.getFixedT` inside loaders and actions.
+  // E.g. The Backend plugin for loading translations from the file system
+  // Tip: You could pass `resources` to the `i18next` configuration and avoid a backend here
+  plugins: [Backend],
 });
 
 export default i18next;

--- a/src/server.ts
+++ b/src/server.ts
@@ -185,7 +185,7 @@ export class RemixI18Next {
 
   private async createInstance(options: Omit<InitOptions, "react"> = {}) {
     let instance = createInstance();
-    const plugins = [
+    let plugins = [
       ...(this.options.backend ? [this.options.backend] : []),
       ...(this.options.plugins || []),
     ];

--- a/src/server.ts
+++ b/src/server.ts
@@ -5,6 +5,7 @@ import type {
 } from "@remix-run/server-runtime";
 import { pick } from "accept-language-parser";
 import {
+  Module,
   BackendModule,
   createInstance,
   InitOptions,
@@ -71,10 +72,16 @@ export interface RemixI18NextOption {
    */
   i18next?: Omit<InitOptions, "react" | "detection"> | null;
   /**
+   * @deprecated Use `plugins` instead.
    * The i18next backend module used to load the translations when creating a
    * new TFunction.
    */
-  backend?: NewableModule<BackendModule<unknown>>;
+  backend?: NewableModule<BackendModule<unknown>> | BackendModule<unknown>;
+  /**
+   * The i18next plugins used to extend the internal i18next instance
+   * when creating a new TFunction.
+   */
+  plugins?: NewableModule<Module>[] | Module[];
   detection: LanguageDetectorOption;
 }
 
@@ -178,7 +185,11 @@ export class RemixI18Next {
 
   private async createInstance(options: Omit<InitOptions, "react"> = {}) {
     let instance = createInstance();
-    if (this.options.backend) instance = instance.use(this.options.backend);
+    const plugins = [
+      ...(this.options.backend ? [this.options.backend] : []),
+      ...(this.options.plugins || []),
+    ];
+    for (const plugin of plugins) instance.use(plugin);
     await instance.init(options);
     return instance;
   }

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,6 +1,7 @@
 import { createCookie, createMemorySessionStorage } from "@remix-run/node";
 import { describe, expect, test } from "vitest";
 import { RemixI18Next } from "../src";
+import { BackendModule, FormatterModule } from "i18next";
 
 describe(RemixI18Next.name, () => {
   describe("getLocale", () => {
@@ -249,6 +250,25 @@ describe(RemixI18Next.name, () => {
   });
 
   describe("getFixedT", () => {
+    const backendPlugin: BackendModule = {
+      type: "backend",
+      init: () => null,
+      read: (_language, _namespace, callback) => {
+        callback(null, {
+          hello: "Hello {{name, uppercase}}",
+        });
+      },
+    };
+    const formatterPlugin: FormatterModule = {
+      type: "formatter",
+      init: () => null,
+      add: () => null,
+      addCached: () => null,
+      format: (value, format) => {
+        if (format === "uppercase") return value.toUpperCase();
+      },
+    };
+
     test("get a fixed T function for server-side usage", async () => {
       let headers = new Headers();
       headers.set("Accept-Language", "fr");
@@ -279,6 +299,71 @@ describe(RemixI18Next.name, () => {
       let t = await i18n.getFixedT(request, "common");
 
       expect(t("Hello {{name}}", { name: "Remix" })).toBe("Bonjour Remix");
+    });
+
+    test("get a fixed T function set with `backend`", async () => {
+      let request = new Request("https://example.com/dashboard?lng=1");
+
+      let i18n = new RemixI18Next({
+        backend: backendPlugin,
+        detection: {
+          supportedLanguages: ["en"],
+          fallbackLanguage: "en",
+        },
+      });
+
+      let t = await i18n.getFixedT(request, "common");
+
+      expect(t("hello", { name: "Remix" })).toBe("Hello Remix");
+    });
+
+    test("get a fixed T function set with single `plugins`", async () => {
+      let request = new Request("https://example.com/dashboard?lng=1");
+
+      let i18n = new RemixI18Next({
+        plugins: [backendPlugin],
+        detection: {
+          supportedLanguages: ["en"],
+          fallbackLanguage: "en",
+        },
+      });
+
+      let t = await i18n.getFixedT(request, "common");
+
+      expect(t("hello", { name: "Remix" })).toBe("Hello Remix");
+    });
+
+    test("get a fixed T function set with multiple `plugins`", async () => {
+      let request = new Request("https://example.com/dashboard?lng=1");
+
+      let i18n = new RemixI18Next({
+        plugins: [backendPlugin, formatterPlugin],
+        detection: {
+          supportedLanguages: ["en"],
+          fallbackLanguage: "en",
+        },
+      });
+
+      let t = await i18n.getFixedT(request, "common");
+
+      expect(t("hello", { name: "Remix" })).toBe("Hello REMIX");
+    });
+
+    test("get a fixed T function set with `backend` and `plugins`", async () => {
+      let request = new Request("https://example.com/dashboard?lng=1");
+
+      let i18n = new RemixI18Next({
+        backend: backendPlugin,
+        plugins: [formatterPlugin],
+        detection: {
+          supportedLanguages: ["en"],
+          fallbackLanguage: "en",
+        },
+      });
+
+      let t = await i18n.getFixedT(request, "common");
+
+      expect(t("hello", { name: "Remix" })).toBe("Hello REMIX");
     });
   });
 });

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -250,7 +250,7 @@ describe(RemixI18Next.name, () => {
   });
 
   describe("getFixedT", () => {
-    const backendPlugin: BackendModule = {
+    let backendPlugin: BackendModule = {
       type: "backend",
       init: () => null,
       read: (_language, _namespace, callback) => {
@@ -259,7 +259,8 @@ describe(RemixI18Next.name, () => {
         });
       },
     };
-    const formatterPlugin: FormatterModule = {
+
+    let formatterPlugin: FormatterModule = {
       type: "formatter",
       init: () => null,
       add: () => null,


### PR DESCRIPTION
Based on this discussion: https://github.com/sergiodxa/remix-i18next/discussions/136

Currently, you can only pass an `i18next` back end module to `RemixI18next` using the `backend` option.

However, it would be useful to be able to pass one or more modules of any type that can be passed to the internal i18next instance.

In my particular use case, I'd like to configure `RemixI18next` to use a custom `I18nFormat` plugin.

### What has changed in this PR?

- Introduce an optional `plugins` option that is an array of `i18next` plugins.
- Deprecate the `backend` option in favour of using `plugins`
- Update the type signature of `backend` to accept `NewableModule<BackendModule<unknown>> | BackendModule<unknown>`
  - This is primarily to simplify test setup to allow plugins to be objects instead of full-blown classes
- Add tests to confirm that plugins are being used by `RemixI18Next`, whether they are set on `backend`, `plugins`, or both
- Update example in README to use `plugins`