### PR TITLE
Update README.md for remix 2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,8 +158,7 @@ And in your `entry.server.tsx` replace the code with this:
 
 ```tsx
 import { PassThrough } from "stream";
-import type { EntryContext } from "@remix-run/node";
-import { Response } from "@remix-run/node";
+import { createReadableStreamFromReadable, type EntryContext } from "@remix-run/node";
 import { RemixServer } from "@remix-run/react";
 import isbot from "isbot";
 import { renderToPipeableStream } from "react-dom/server";
@@ -205,12 +204,13 @@ export default async function handleRequest(
       </I18nextProvider>,
       {
         [callbackName]: () => {
-          let body = new PassThrough();
+          const body = new PassThrough();
+          const stream = createReadableStreamFromReadable(body);
 
           responseHeaders.set("Content-Type", "text/html");
 
           resolve(
-            new Response(body, {
+            new Response(stream, {
               headers: responseHeaders,
               status: didError ? 500 : responseStatusCode,
             })


### PR DESCRIPTION
As written on https://remix.run/docs/en/main/start/v2#removal-of-exported-polyfills:

> Remix v2 also no longer exports these polyfilled implementations from @remix-run/node, and instead you should just use the instances in the global namespace. One place this is likely to surface and require a change is your app/entry.server.tsx file, where you'll also need to convert the Node PassThrough into a web ReadableStream via createReadableStreamFromReadable

Thats why the boilerplate code in the README.md is not working for Remix 2.0. The updated version will convert the Node PassThrough into a web ReadableStream via createReadableStreamFromReadable.

Also Remix V2 has no longer the exported member 'Response', that's why you need to remove it from the imports.