### PR TITLE
Use react-i18next 13 or 14 peer dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,7 @@
         "i18next": "^23.1.0",
         "prettier": "^2.8.8",
         "react": "^18.2.0",
-        "react-i18next": "^13.0.0",
+        "react-i18next": "^14.0.0",
         "ts-node": "^10.9.1",
         "typescript": "^5.1.0",
         "vitest": "^0.25.3"
@@ -47,7 +47,7 @@
         "@remix-run/server-runtime": "^1.0.0 || ^2.0.0",
         "i18next": "^23.1.0",
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
-        "react-i18next": "^13.0.0"
+        "react-i18next": "^13.0.0 || ^14.0.0"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -695,12 +695,12 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.22.5.tgz",
-      "integrity": "sha512-ecjvYlnAaZ/KVneE/OdKYBYfgXV3Ptu6zQWmgEF7vwKhQnvVS6bjMD2XYgj+SNvQ1GfK/pjgokfPkC/2CO8CuA==",
+      "version": "7.23.6",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.23.6.tgz",
+      "integrity": "sha512-zHd0eUrf5GZoOWVCXp6koAKQTfZV07eit6bGPmJgnZdnSAvvZee6zniW2XMF7Cmc4ISOOnPy3QaSiIJGJkVEDQ==",
       "dev": true,
       "dependencies": {
-        "regenerator-runtime": "^0.13.11"
+        "regenerator-runtime": "^0.14.0"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -5532,9 +5532,9 @@
       }
     },
     "node_modules/i18next": {
-      "version": "23.1.0",
-      "resolved": "https://registry.npmjs.org/i18next/-/i18next-23.1.0.tgz",
-      "integrity": "sha512-CObNPofJpw7zGVGYLd58mtMZUF+NZQl9czYMihbJkStjX+Nlu9kC3PHiC6uE1niP3qxP/3ocLXIBc2zqbAb1dg==",
+      "version": "23.7.11",
+      "resolved": "https://registry.npmjs.org/i18next/-/i18next-23.7.11.tgz",
+      "integrity": "sha512-A/vOkw8vY99YHU9A1Td3I1dcTiYaPnwBWzrpVzfXUXSYgogK3cmBcmop/0cnXPc6QpUWIyqaugKNxRUEZVk9Nw==",
       "dev": true,
       "funding": [
         {
@@ -5551,7 +5551,7 @@
         }
       ],
       "dependencies": {
-        "@babel/runtime": "^7.22.5"
+        "@babel/runtime": "^7.23.2"
       }
     },
     "node_modules/iconv-lite": {
@@ -8591,16 +8591,16 @@
       }
     },
     "node_modules/react-i18next": {
-      "version": "13.0.0",
-      "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-13.0.0.tgz",
-      "integrity": "sha512-qRFbrSgynsBSjfnSTb/Um3mw9uPjOfDi4Iq2rMCuzfsRsYGdkEdyCr0i+T0bR0bG6xwULvK4k1oRVLLd7ZDBVw==",
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-14.0.0.tgz",
+      "integrity": "sha512-OCrS8rHNAmnr8ggGRDxjakzihrMW7HCbsplduTm3EuuQ6fyvWGT41ksZpqbduYoqJurBmEsEVZ1pILSUWkHZng==",
       "dev": true,
       "dependencies": {
         "@babel/runtime": "^7.22.5",
         "html-parse-stringify": "^3.0.1"
       },
       "peerDependencies": {
-        "i18next": ">= 23.0.1",
+        "i18next": ">= 23.2.3",
         "react": ">= 16.8.0"
       },
       "peerDependenciesMeta": {
@@ -8788,9 +8788,9 @@
       }
     },
     "node_modules/regenerator-runtime": {
-      "version": "0.13.11",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
-      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
+      "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
       "dev": true
     },
     "node_modules/regexp-tree": {
@@ -11671,12 +11671,12 @@
       }
     },
     "@babel/runtime": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.22.5.tgz",
-      "integrity": "sha512-ecjvYlnAaZ/KVneE/OdKYBYfgXV3Ptu6zQWmgEF7vwKhQnvVS6bjMD2XYgj+SNvQ1GfK/pjgokfPkC/2CO8CuA==",
+      "version": "7.23.6",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.23.6.tgz",
+      "integrity": "sha512-zHd0eUrf5GZoOWVCXp6koAKQTfZV07eit6bGPmJgnZdnSAvvZee6zniW2XMF7Cmc4ISOOnPy3QaSiIJGJkVEDQ==",
       "dev": true,
       "requires": {
-        "regenerator-runtime": "^0.13.11"
+        "regenerator-runtime": "^0.14.0"
       }
     },
     "@babel/template": {
@@ -15063,12 +15063,12 @@
       "dev": true
     },
     "i18next": {
-      "version": "23.1.0",
-      "resolved": "https://registry.npmjs.org/i18next/-/i18next-23.1.0.tgz",
-      "integrity": "sha512-CObNPofJpw7zGVGYLd58mtMZUF+NZQl9czYMihbJkStjX+Nlu9kC3PHiC6uE1niP3qxP/3ocLXIBc2zqbAb1dg==",
+      "version": "23.7.11",
+      "resolved": "https://registry.npmjs.org/i18next/-/i18next-23.7.11.tgz",
+      "integrity": "sha512-A/vOkw8vY99YHU9A1Td3I1dcTiYaPnwBWzrpVzfXUXSYgogK3cmBcmop/0cnXPc6QpUWIyqaugKNxRUEZVk9Nw==",
       "dev": true,
       "requires": {
-        "@babel/runtime": "^7.22.5"
+        "@babel/runtime": "^7.23.2"
       }
     },
     "iconv-lite": {
@@ -17136,9 +17136,9 @@
       }
     },
     "react-i18next": {
-      "version": "13.0.0",
-      "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-13.0.0.tgz",
-      "integrity": "sha512-qRFbrSgynsBSjfnSTb/Um3mw9uPjOfDi4Iq2rMCuzfsRsYGdkEdyCr0i+T0bR0bG6xwULvK4k1oRVLLd7ZDBVw==",
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-14.0.0.tgz",
+      "integrity": "sha512-OCrS8rHNAmnr8ggGRDxjakzihrMW7HCbsplduTm3EuuQ6fyvWGT41ksZpqbduYoqJurBmEsEVZ1pILSUWkHZng==",
       "dev": true,
       "requires": {
         "@babel/runtime": "^7.22.5",
@@ -17273,9 +17273,9 @@
       }
     },
     "regenerator-runtime": {
-      "version": "0.13.11",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
-      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
+      "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
       "dev": true
     },
     "regexp-tree": {

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "@remix-run/server-runtime": "^1.0.0 || ^2.0.0",
     "i18next": "^23.1.0",
     "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
-    "react-i18next": "^13.0.0"
+    "react-i18next": "^13.0.0 || ^14.0.0"
   },
   "dependencies": {
     "accept-language-parser": "^1.5.0",
@@ -85,7 +85,7 @@
     "i18next": "^23.1.0",
     "prettier": "^2.8.8",
     "react": "^18.2.0",
-    "react-i18next": "^13.0.0",
+    "react-i18next": "^14.0.0",
     "ts-node": "^10.9.1",
     "typescript": "^5.1.0",
     "vitest": "^0.25.3"


### PR DESCRIPTION
Upgrades to using react-i18next 14 for development as well.

The change between react-i18next 13 and 14 only affects `reportNamespaces` which is not used by remix-i18next so this change should be safe:
https://github.com/i18next/react-i18next/blob/master/CHANGELOG.md

