### PR TITLE
fix(docs): suggest users to explicitly set utf-8 charset

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ export default async function handleRequest(
 				[callbackName]: () => {
 					let body = new PassThrough();
 					const stream = createReadableStreamFromReadable(body);
-					responseHeaders.set("Content-Type", "text/html");
+					responseHeaders.set("Content-Type", "text/html; charset=utf-8");
 
 					resolve(
 						new Response(stream, {


### PR DESCRIPTION
## Summary:

Suggest users to explicitly define UTF-8 charset in entry.server.tsx to avoid hydration errors.

## Changes made:

Added a `charset=utf-8` bit to `handleRequest()` example configuration in README.md.

## Screenshots:

Before:
![image](https://github.com/sergiodxa/remix-i18next/assets/127086308/eea7968c-39f0-4ed6-be32-b6c64f2791ba)
![image](https://github.com/sergiodxa/remix-i18next/assets/127086308/a48e98bd-975e-46fd-999e-0afc069c0e31)

After:
![image](https://github.com/sergiodxa/remix-i18next/assets/127086308/b75f8215-3272-4e60-86cd-c08c077388d6)