### PR TITLE
Add funding option to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
   "bugs": {
     "url": "https://github.com/sergiodxa/remix-i18next/issues"
   },
+  "funding": "https://github.com/sponsors/sergiodxa",
   "keywords": [
     "remix",
     "i18n",


### PR DESCRIPTION
Adds a funding option to the `package.json` file to support the project financially.
- Adds a `"funding"` field with the URL "https://github.com/sponsors/sergiodxa" to the `package.json` file, enabling users to easily find and access the sponsorship page for the project maintainer.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/sergiodxa/remix-i18next?shareId=816de31e-6051-44aa-bd0f-af93254af2ea).