### PR TITLE
Avoid calling changeLanguage if it's the same as locale

### DIFF
--- a/src/react.tsx
+++ b/src/react.tsx
@@ -30,6 +30,6 @@ export function useLocale(localeKey = "locale"): string {
 export function useChangeLanguage(locale: string) {
 	let { i18n } = useTranslation();
 	React.useEffect(() => {
-		i18n.changeLanguage(locale);
+		if (i18n.language !== locale) i18n.changeLanguage(locale);
 	}, [locale, i18n]);
 }


### PR DESCRIPTION
Right now if locale change the `changeLanguage` function is called, this function triggers a re-render of every component using `useTranslation`.

Instead we can check if `i18n.language` is different to the locale and only then call `changeLanguage`.