### PR TITLE
Handle additional whitespaces and don't throw exception on invalid locale

### DIFF
--- a/src/lib/get-client-locales.test.ts
+++ b/src/lib/get-client-locales.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, test } from "bun:test";
+import * as getClientLocales from "./get-client-locales.js";
+
+describe(getClientLocales.getClientLocales.name, () => {
+	test('should not throw on invalid locales', () => {
+		let headers = new Headers();
+		headers.set("Accept-Language", "cs-CZ,cs;q=0.9,true;q=0.8,en-US;q=0.7,en;q=0.6");
+		expect(() => getClientLocales.getClientLocales(headers)).not.toThrowError(RangeError)
+	});
+});

--- a/src/lib/get-client-locales.ts
+++ b/src/lib/get-client-locales.ts
@@ -28,11 +28,25 @@ export function getClientLocales(requestOrHeaders: Request | Headers): Locales {
 	// if the header is not defined, return undefined
 	if (!acceptLanguage) return undefined;
 
+	let parsedLocales = parse(acceptLanguage)
+	.filter((lang) => lang.code !== "*")
+	.map(formatLanguageString);
+
+	let validLocales: string[] = []
+
+	for (let locale of parsedLocales) {
+		try {
+			// This will throw on invalid locales
+			new Intl.Locale(locale);
+
+			// If we get here, the locale is valid
+			validLocales.push(locale);
+		} catch {}
+	}
+
 	let locale = pick(
 		Intl.DateTimeFormat.supportedLocalesOf(
-			parse(acceptLanguage)
-				.filter((lang) => lang.code !== "*")
-				.map(formatLanguageString),
+			validLocales,
 		),
 		acceptLanguage,
 	);

--- a/src/lib/parser.test.ts
+++ b/src/lib/parser.test.ts
@@ -85,6 +85,15 @@ describe(parser.parse.name, () => {
 			{ code: "en", quality: 0.4, script: null },
 			{ code: "*", quality: 0.1, script: null },
 		]);
+
+		let result2 = parser.parse("zh-CN, zh; q=0.9, en; q=0.8, ko; q=0.7");
+
+		expect(result2).toEqual([
+			{ code: "zh", region: "CN", quality: 1.0, script: null },
+			{ code: "zh", quality: 0.9, script: null },
+			{ code: "en", quality: 0.8, script: null },
+			{ code: "ko", quality: 0.7, script: null },
+		]);
 	});
 
 	test("should sort based on quality value", () => {

--- a/src/lib/parser.ts
+++ b/src/lib/parser.ts
@@ -1,6 +1,6 @@
 import { formatLanguageString } from "./format-language-string.js";
 
-let REGEX = /((([a-zA-Z]+(-[a-zA-Z0-9]+){0,2})|\*)(;q=[0-1](\.[0-9]+)?)?)*/g;
+let REGEX = /[ ]*((([a-zA-Z]+(-[a-zA-Z0-9]+){0,2})|\*)(;[ ]*q=[0-1](\.[0-9]+)?[ ]*)?)*/g;
 
 export interface Language {
 	code: string;
@@ -25,6 +25,9 @@ export function parse(acceptLanguage?: string): Language[] {
 
 	for (let m of strings) {
 		if (!m) continue;
+
+		m = m.trim();
+
 		let bits = m.split(";");
 		let ietf = bits[0]?.split("-") ?? [];
 		let hasScript = ietf.length === 3;


### PR DESCRIPTION
Hi, following up on my #207 and someones #209. 

This PR consists of two changes.

## Filter out invalid locales instead of throwing exceptions

I have MANY thrown exception in Sentry from my users. Sometimes it's just bots, sometimes it's a weird combination of environment and browsers. However sometimes a request i received contains an invalid locale (see tests, there are real world `Accept-Language` headers). In my opinion it's better to gracefully filter out one of the invalid locales instead of throwing an exception (`Intl.DateTimeFormat.supportedLocalesOf` does that)

## Better handling of whitespaces
Even though you have tests for random whitespaces, it doesn't handle all the cases as i have observed. The [specification](https://datatracker.ietf.org/doc/html/rfc3282#section-3) specifies multiple places where whitespaces can occur, i have handled the additional whitespaces and also made a test from one of my Sentry errors that bypassed your test.