### PR TITLE
Replace Array#at with array[I] to support more browsers

### DIFF
--- a/src/react.tsx
+++ b/src/react.tsx
@@ -14,7 +14,7 @@ import { useTranslation } from "react-i18next";
 export function useLocale(localeKey = "locale"): string {
 	let matches = useMatches();
 	// biome-ignore lint/style/noNonNullAssertion: There's always a root match
-	let rootMatch = matches.at(0)!;
+	let rootMatch = matches[0]!;
 	let { [localeKey]: locale } =
 		(rootMatch.data as Record<string, string>) ?? {};
 	if (!locale) throw new Error("Missing locale returned by the root loader.");


### PR DESCRIPTION
I have finally figured out the #207 issue.

I was actually dealing with two different issues, not just one. The first one was fixed in the PR that you approved. It was about parsing the `Accept-Language`. However #207 still occurred in Sentry.

I couldn't figure out the error at first, but today morning i realized it's not about reading undefined root loader but that `Array.prototype.at` function is not supported in a lot of non-standard browsers.

Sure, i couldn't care less about MuiBrowser, etc.. However my B2B platform is really important for people who sell online. Which means they provide links to my platform on Instagram, Facebook, etc.. And they use weird browsers which in Sentry appear just as `Instagram {version}`, `Facebook {version}`, etc.. And they don't support the `.at` function on `Array` 🙃 (not always but many times if people don't update instagram) 