### PR TITLE
Add support for async function in i18next options

### DIFF
--- a/src/middleware.test.ts
+++ b/src/middleware.test.ts
@@ -81,4 +81,25 @@ describe(unstable_createI18nextMiddleware.name, () => {
 		expect(getLocale(context)).toBe("es");
 		expect(getInstance(context).language).toBe("es");
 	});
+
+	test("supports async function for i18next options", async () => {
+		let [middleware, , getInstance] = unstable_createI18nextMiddleware({
+			detection: { fallbackLanguage: "en", supportedLanguages: ["es", "en"] },
+			i18next: async () => {
+				// Simulate async operation (e.g., fetching from API/database)
+				return {
+					resources: { en: { translation: { asyncKey: "asyncValue" } } },
+				};
+			},
+		});
+
+		let context = new unstable_RouterContextProvider();
+		await runMiddleware(middleware, { context });
+
+		let instance = getInstance(context);
+
+		expect(instance).toBeDefined();
+		expect(instance.isInitialized).toBe(true);
+		expect(instance.t("asyncKey")).toBe("asyncValue");
+	});
 });

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -22,7 +22,8 @@ export function unstable_createI18nextMiddleware({
 			let lng = await languageDetector.detect(request);
 			context.set(localeContext, lng);
 
-			let instance = createInstance(i18next);
+			let options = typeof i18next === "function" ? await i18next() : i18next;
+			let instance = createInstance(options);
 			for (const plugin of plugins ?? []) instance.use(plugin);
 			await instance.init({ lng });
 			context.set(i18nextContext, instance);
@@ -38,8 +39,11 @@ export namespace unstable_createI18nextMiddleware {
 	export interface Options {
 		/**
 		 * The i18next options used to initialize the internal i18next instance.
+		 * Can be an object or an async function that returns the options.
 		 */
-		i18next?: Omit<InitOptions, "detection">;
+		i18next?:
+			| Omit<InitOptions, "detection">
+			| (() => Promise<Omit<InitOptions, "detection">>);
 		/**
 		 * The i18next plugins used to extend the internal i18next instance
 		 * when creating a new TFunction.


### PR DESCRIPTION
A lot of the times, the translation file comes from a outside cms system or maybe from database, so the i18n option needs to be initialized asynchronously.

this pr enhanced the `unstable_createI18nextMiddleware` to accept an async function for i18next options.