### PR TITLE
Mark middleware as stable

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,19 +60,14 @@ The type import and the `satisfies` are optional, but it will help us ensure tha
 
 ### Setup the Middleware
 
-Enable middleware in your react-router.config.ts:
-
-```ts
-import type { Config } from "@react-router/dev/config";
-
-export default {
-  future: {
-    v8_middleware: true,
-  },
-} satisfies Config;
-```
+Ensure middleware is enabled in your React Router config so the middleware can run.
+See the React Router middleware documentation for details: https://reactrouter.com/how-to/middleware
 
 Create a file named `app/middleware/i18next.ts` with the following code:
+
+> [!CAUTION]
+> This depends on `react-router@7.9.0` or later
+> Check older versions of the README for a guide on how to use RemixI18next class instead if you are using an older version of React Router or don't want to use the middleware.
 
 ```ts
 import { createI18nextMiddleware } from "remix-i18next/middleware";

--- a/README.md
+++ b/README.md
@@ -60,19 +60,27 @@ The type import and the `satisfies` are optional, but it will help us ensure tha
 
 ### Setup the Middleware
 
-Create a file named `app/middleware/i18next.ts` with the following code:
-
-> [!CAUTION]
-> This depends on `react-router@7.3.0` or later, and it's considered unstable until React Router middleware feature itself is considered stable. Breaking changes may happen in minor versions.
-> Check older versions of the README for a guide on how to use RemixI18next class instead if you are using an older version of React Router or don't want to use the middleware.
+Enable middleware in your react-router.config.ts:
 
 ```ts
-import { unstable_createI18nextMiddleware } from "remix-i18next/middleware";
+import type { Config } from "@react-router/dev/config";
+
+export default {
+  future: {
+    v8_middleware: true,
+  },
+} satisfies Config;
+```
+
+Create a file named `app/middleware/i18next.ts` with the following code:
+
+```ts
+import { createI18nextMiddleware } from "remix-i18next/middleware";
 import en from "~/locales/en";
 import es from "~/locales/es";
 
 export const [i18nextMiddleware, getLocale, getInstance] =
-  unstable_createI18nextMiddleware({
+  createI18nextMiddleware({
     detection: {
       supportedLanguages: ["en", "es"],
       fallbackLanguage: "en",
@@ -89,7 +97,7 @@ Then in your `app/root.tsx` setup the middleware:
 ```ts
 import { i18nextMiddleware } from "~/middleware/i18next";
 
-export const unstable_middleware = [i18nextMiddleware];
+export const middleware = [i18nextMiddleware];
 ```
 
 With this, on every request, the middleware will run, detect the language and set it in the router context.
@@ -178,7 +186,7 @@ import {
 } from "./middleware/i18next";
 import { useTranslation } from "react-i18next";
 
-export const unstable_middleware = [i18nextMiddleware];
+export const middleware = [i18nextMiddleware];
 
 export async function loader({ context }: Route.LoaderArgs) {
   let locale = getLocale(context);
@@ -340,7 +348,7 @@ import { PassThrough } from "node:stream";
 
 import type {
   EntryContext,
-  unstable_RouterContextProvider,
+  RouterContextProvider,
 } from "react-router";
 import { createReadableStreamFromReadable } from "@react-router/node";
 import { ServerRouter } from "react-router";
@@ -357,7 +365,7 @@ export default function handleRequest(
   responseStatusCode: number,
   responseHeaders: Headers,
   entryContext: EntryContext,
-  routerContext: unstable_RouterContextProvider
+  routerContext: RouterContextProvider
 ) {
   return new Promise((resolve, reject) => {
     let shellRendered = false;
@@ -417,10 +425,10 @@ First option is to ignore the locale detected by the middleware and manually gra
 Second options is to pass a `findLocale` function to the detection options in the middleware.
 
 ```ts
-import { unstable_createI18nextMiddleware } from "remix-i18next/middleware";
+import { createI18nextMiddleware } from "remix-i18next/middleware";
 
 export const [i18nextMiddleware, getLocale, getInstance] =
-  unstable_createI18nextMiddleware({
+  createI18nextMiddleware({
     detection: {
       supportedLanguages: ["es", "en"],
       fallbackLanguage: "en",
@@ -472,11 +480,11 @@ export const localeCookie = createCookie("lng", {
 Then you can pass the cookie to the middleware:
 
 ```ts
-import { unstable_createI18nextMiddleware } from "remix-i18next/middleware";
+import { createI18nextMiddleware } from "remix-i18next/middleware";
 import { localeCookie } from "~/cookies";
 
 export const [i18nextMiddleware, getLocale, getInstance] =
-  unstable_createI18nextMiddleware({
+  createI18nextMiddleware({
     detection: {
       supportedLanguages: ["es", "en"],
       fallbackLanguage: "en",
@@ -527,11 +535,11 @@ export const sessionStorage = createCookieSessionStorage({
 Then you can pass the session to the middleware:
 
 ```ts
-import { unstable_createI18nextMiddleware } from "remix-i18next/middleware";
+import { createI18nextMiddleware } from "remix-i18next/middleware";
 import { sessionStorage } from "~/session";
 
 export const [i18nextMiddleware, getLocale, getInstance] =
-  unstable_createI18nextMiddleware({
+  createI18nextMiddleware({
     detection: {
       supportedLanguages: ["es", "en"],
       fallbackLanguage: "en",

--- a/bun.lock
+++ b/bun.lock
@@ -15,7 +15,7 @@
         "react": "^19.1.1",
         "react-dom": "^19.1.1",
         "react-i18next": "^15.7.1",
-        "react-router": "^7.8.2",
+        "react-router": "^7.9.1",
         "typedoc": "^0.28.6",
         "typedoc-plugin-mdn-links": "^5.0.1",
         "typescript": "^5.7.2",
@@ -187,7 +187,7 @@
 
     "react-i18next": ["react-i18next@15.7.1", "", { "dependencies": { "@babel/runtime": "^7.27.6", "html-parse-stringify": "^3.0.1" }, "peerDependencies": { "i18next": ">= 23.4.0", "react": ">= 16.8.0", "typescript": "^5" }, "optionalPeers": ["typescript"] }, "sha512-o4VsKh30fy7p0z5ACHuyWqB6xu9WpQIQy2/ZcbCqopNnrnTVOPn/nAv9uYP4xYAWg99QMpvZ9Bu/si3eGurzGw=="],
 
-    "react-router": ["react-router@7.8.2", "", { "dependencies": { "cookie": "^1.0.1", "set-cookie-parser": "^2.6.0" }, "peerDependencies": { "react": ">=18", "react-dom": ">=18" }, "optionalPeers": ["react-dom"] }, "sha512-7M2fR1JbIZ/jFWqelpvSZx+7vd7UlBTfdZqf6OSdF9g6+sfdqJDAWcak6ervbHph200ePlu+7G8LdoiC3ReyAQ=="],
+    "react-router": ["react-router@7.9.1", "", { "dependencies": { "cookie": "^1.0.1", "set-cookie-parser": "^2.6.0" }, "peerDependencies": { "react": ">=18", "react-dom": ">=18" }, "optionalPeers": ["react-dom"] }, "sha512-pfAByjcTpX55mqSDGwGnY9vDCpxqBLASg0BMNAuMmpSGESo/TaOUG6BllhAtAkCGx8Rnohik/XtaqiYUJtgW2g=="],
 
     "require-directory": ["require-directory@2.1.1", "", {}, "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q=="],
 

--- a/package.json
+++ b/package.json
@@ -22,13 +22,13 @@
 		"react": "^19.1.1",
 		"react-dom": "^19.1.1",
 		"react-i18next": "^15.7.1",
-		"react-router": "^7.8.2",
+		"react-router": "^7.9.1",
 		"typedoc": "^0.28.6",
 		"typedoc-plugin-mdn-links": "^5.0.1",
 		"typescript": "^5.7.2"
 	},
 	"peerDependencies": {
-		"react-router": "^7.0.0",
+		"react-router": "^7.9.1",
 		"i18next": "^24.0.0 || ^25.0.0",
 		"react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
 		"react-i18next": "^13.0.0 || ^14.0.0 || ^15.0.0"

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
 		"typescript": "^5.7.2"
 	},
 	"peerDependencies": {
-		"react-router": "^7.9.1",
+		"react-router": "^7.0.0",
 		"i18next": "^24.0.0 || ^25.0.0",
 		"react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
 		"react-i18next": "^13.0.0 || ^14.0.0 || ^15.0.0"

--- a/src/lib/test-helper.ts
+++ b/src/lib/test-helper.ts
@@ -1,8 +1,8 @@
 import { mock } from "bun:test";
 import {
+	type MiddlewareFunction,
 	type Params,
-	type unstable_MiddlewareFunction,
-	unstable_RouterContextProvider,
+	RouterContextProvider,
 } from "react-router";
 
 declare module "i18next" {
@@ -24,15 +24,15 @@ const defaultNext = mock().mockImplementation(() => Response.json(null));
 interface RunMiddlewareOptions<T = Response> {
 	request?: Request;
 	params?: Params;
-	context?: Readonly<unstable_RouterContextProvider>;
+	context?: Readonly<RouterContextProvider>;
 	next?: () => Promise<T>;
 }
 
 export async function runMiddleware<T = Response>(
-	middleware: unstable_MiddlewareFunction<T>,
+	middleware: MiddlewareFunction<T>,
 	{
 		request = new Request("https://remix.utils"),
-		context = new unstable_RouterContextProvider(),
+		context = new RouterContextProvider(),
 		params = {},
 		next = defaultNext,
 	}: RunMiddlewareOptions<T> = {},

--- a/src/middleware.test.ts
+++ b/src/middleware.test.ts
@@ -1,23 +1,23 @@
 import { describe, expect, test } from "bun:test";
 
-import { unstable_RouterContextProvider } from "react-router";
+import { RouterContextProvider } from "react-router";
 import { runMiddleware } from "./lib/test-helper";
-import { unstable_createI18nextMiddleware } from "./middleware";
+import { createI18nextMiddleware } from "./middleware";
 
-describe(unstable_createI18nextMiddleware.name, () => {
+describe(createI18nextMiddleware.name, () => {
 	test("sets the locale in context", async () => {
-		let [middleware, getLocale] = unstable_createI18nextMiddleware({
+		let [middleware, getLocale] = createI18nextMiddleware({
 			detection: { fallbackLanguage: "en", supportedLanguages: ["es", "en"] },
 		});
 
-		let context = new unstable_RouterContextProvider();
+		let context = new RouterContextProvider();
 		await runMiddleware(middleware, { context });
 
 		expect(getLocale(context)).toBe("en");
 	});
 
 	test("detects locale from request and saves it in context", async () => {
-		let [middleware, getLocale] = unstable_createI18nextMiddleware({
+		let [middleware, getLocale] = createI18nextMiddleware({
 			detection: { fallbackLanguage: "en", supportedLanguages: ["es", "en"] },
 		});
 
@@ -25,7 +25,7 @@ describe(unstable_createI18nextMiddleware.name, () => {
 			headers: { "Accept-Language": "es" },
 		});
 
-		let context = new unstable_RouterContextProvider();
+		let context = new RouterContextProvider();
 
 		await runMiddleware(middleware, { request, context });
 
@@ -33,11 +33,11 @@ describe(unstable_createI18nextMiddleware.name, () => {
 	});
 
 	test("can access i18next instance", async () => {
-		let [middleware, , getInstance] = unstable_createI18nextMiddleware({
+		let [middleware, , getInstance] = createI18nextMiddleware({
 			detection: { fallbackLanguage: "en", supportedLanguages: ["es", "en"] },
 		});
 
-		let context = new unstable_RouterContextProvider();
+		let context = new RouterContextProvider();
 		await runMiddleware(middleware, { context });
 
 		let instance = getInstance(context);
@@ -47,34 +47,32 @@ describe(unstable_createI18nextMiddleware.name, () => {
 	});
 
 	test("can access TFunction from instance", async () => {
-		let [middleware, , getInstance] = unstable_createI18nextMiddleware({
+		let [middleware, , getInstance] = createI18nextMiddleware({
 			detection: { fallbackLanguage: "en", supportedLanguages: ["es", "en"] },
 			i18next: {
 				resources: { en: { translation: { key: "value" } } },
 			},
 		});
 
-		let context = new unstable_RouterContextProvider();
+		let context = new RouterContextProvider();
 		await runMiddleware(middleware, { context });
 
 		expect(getInstance(context).t("key")).toBe("value");
 	});
 
 	test("the instance has the detected locale configured", async () => {
-		let [middleware, getLocale, getInstance] = unstable_createI18nextMiddleware(
-			{
-				detection: {
-					fallbackLanguage: "en",
-					supportedLanguages: ["es", "en"],
-				},
+		let [middleware, getLocale, getInstance] = createI18nextMiddleware({
+			detection: {
+				fallbackLanguage: "en",
+				supportedLanguages: ["es", "en"],
 			},
-		);
+		});
 
 		let request = new Request("http://example.com", {
 			headers: { "Accept-Language": "es" },
 		});
 
-		let context = new unstable_RouterContextProvider();
+		let context = new RouterContextProvider();
 
 		await runMiddleware(middleware, { request, context });
 

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,20 +1,17 @@
 import type { InitOptions, i18n, Module, NewableModule } from "i18next";
 import { createInstance } from "i18next";
-import type {
-	unstable_MiddlewareFunction,
-	unstable_RouterContextProvider,
-} from "react-router";
-import { unstable_createContext } from "react-router";
+import type { MiddlewareFunction, RouterContextProvider } from "react-router";
+import { createContext } from "react-router";
 import type { LanguageDetectorOption } from "./lib/language-detector.js";
 import { LanguageDetector } from "./lib/language-detector.js";
 
-export function unstable_createI18nextMiddleware({
+export function createI18nextMiddleware({
 	detection,
 	i18next = {},
 	plugins = [],
-}: unstable_createI18nextMiddleware.Options): unstable_createI18nextMiddleware.ReturnType {
-	let localeContext = unstable_createContext<string>();
-	let i18nextContext = unstable_createContext<i18n>();
+}: createI18nextMiddleware.Options): createI18nextMiddleware.ReturnType {
+	let localeContext = createContext<string>();
+	let i18nextContext = createContext<i18n>();
 	let languageDetector = new LanguageDetector(detection);
 
 	return [
@@ -34,7 +31,7 @@ export function unstable_createI18nextMiddleware({
 	];
 }
 
-export namespace unstable_createI18nextMiddleware {
+export namespace createI18nextMiddleware {
 	export interface Options {
 		/**
 		 * The i18next options used to initialize the internal i18next instance.
@@ -49,8 +46,8 @@ export namespace unstable_createI18nextMiddleware {
 	}
 
 	export type ReturnType = [
-		unstable_MiddlewareFunction<Response>,
-		(context: Readonly<unstable_RouterContextProvider>) => string,
-		(context: Readonly<unstable_RouterContextProvider>) => i18n,
+		MiddlewareFunction<Response>,
+		(context: Readonly<RouterContextProvider>) => string,
+		(context: Readonly<RouterContextProvider>) => i18n,
 	];
 }


### PR DESCRIPTION
Bump react-router to 7.9.1, where middleware and context APIs were stabilized.

CHANGELOG of `react-router@7.9.0`  can be found here:
https://github.com/remix-run/react-router/blob/main/packages/react-router/CHANGELOG.md#790
