### PR TITLE
Adjust server side instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -380,8 +380,8 @@ import { PassThrough } from "node:stream";
  import { isbot } from "isbot";
  import type { RenderToPipeableStreamOptions } from "react-dom/server";
  import { renderToPipeableStream } from "react-dom/server";
-+import {I18nextProvider} from "react-i18next"
-+import {getInstance} from "~/middleware/i18next"
++import {I18nextProvider} from "react-i18next";
++import {getInstance} from "~/middleware/i18next";
 +
  
  export const streamTimeout = 5_000;

--- a/README.md
+++ b/README.md
@@ -372,7 +372,7 @@ Apply the following changes to your `entry.server.tsx`
 
 ```patch
 import { PassThrough } from "node:stream";
- 
+
 -import type { AppLoadContext, EntryContext } from "react-router";
 +import type { RouterContextProvider, EntryContext } from "react-router";
  import { createReadableStreamFromReadable } from "@react-router/node";
@@ -383,27 +383,27 @@ import { PassThrough } from "node:stream";
 +import {I18nextProvider} from "react-i18next";
 +import {getInstance} from "~/middleware/i18next";
 +
- 
+
  export const streamTimeout = 5_000;
- 
+
 @@ -14,9 +17,7 @@ export default function handleRequest(
    responseStatusCode: number,
    responseHeaders: Headers,
-   routerContext: EntryContext,
+   entryContext: EntryContext,
 -  loadContext: AppLoadContext,
 -  // If you have middleware enabled:
--  // loadContext: RouterContextProvider
-+  loadContext: RouterContextProvider
+-  // routerContext: RouterContextProvider
++  routerContext: RouterContextProvider
  ) {
    return new Promise((resolve, reject) => {
      let shellRendered = false;
 @@ -37,7 +38,9 @@ export default function handleRequest(
      );
- 
+
      const { pipe, abort } = renderToPipeableStream(
 -      <ServerRouter context={routerContext} url={request.url} />,
-+      <I18nextProvider i18n={getInstance(loadContext)}>
-+        <ServerRouter context={routerContext} url={request.url} />
++      <I18nextProvider i18n={getInstance(routerContext)}>
++        <ServerRouter context={entryContext} url={request.url} />
 +      </I18nextProvider>,
        {
 ```


### PR DESCRIPTION
The current example code in the README is not based on the most recent version of  [entry.server.node.tsx](https://github.com/remix-run/react-router/blob/64f82f1581bd5e72a9312802c60bb61b9278135a/packages/react-router-dev/config/defaults/entry.server.node.tsx)

Some examples:
https://github.com/remix-run/react-router/blob/64f82f1581bd5e72a9312802c60bb61b9278135a/packages/react-router-dev/config/defaults/entry.server.node.tsx#L17-L19

https://github.com/remix-run/react-router/blob/64f82f1581bd5e72a9312802c60bb61b9278135a/packages/react-router-dev/config/defaults/entry.server.node.tsx#L34-L37

Updated the code from a full file to a patch because it's easier to understand the actual changes and apply accordingly based on the setup and version used. 