### PR TITLE
Add optional context to the custom findLocale function

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -16,7 +16,7 @@ export function createI18nextMiddleware({
 
 	return [
 		async function i18nextMiddleware({ request, context }, next) {
-			let lng = await languageDetector.detect(request);
+			let lng = await languageDetector.detect(request, context);
 			context.set(localeContext, lng);
 
 			let instance = createInstance(i18next);

--- a/src/server.ts
+++ b/src/server.ts
@@ -10,7 +10,7 @@ import {
 	type NewableModule,
 	type TFunction,
 } from "i18next";
-import type { EntryContext } from "react-router";
+import type { EntryContext, RouterContextProvider } from "react-router";
 import {
 	LanguageDetector,
 	type LanguageDetectorOption,
@@ -58,8 +58,8 @@ export class RemixI18Next {
 	 * - header
 	 * And finally the fallback language.
 	 */
-	public async getLocale(request: Request): Promise<string> {
-		return this.detector.detect(request);
+	public async getLocale(request: Request, context?: Readonly<RouterContextProvider>): Promise<string> {
+		return this.detector.detect(request, context);
 	}
 
 	/**
@@ -109,6 +109,7 @@ export class RemixI18Next {
 		locale: string,
 		namespaces?: N,
 		options?: Omit<InitOptions, "react"> & { keyPrefix?: KPrefix },
+        context?: Readonly<RouterContextProvider>
 	): Promise<TFunction<FallbackNs<N>, KPrefix>>;
 	async getFixedT<
 		N extends
@@ -119,6 +120,7 @@ export class RemixI18Next {
 		request: Request,
 		namespaces?: N,
 		options?: Omit<InitOptions, "react"> & { keyPrefix?: KPrefix },
+        context?: Readonly<RouterContextProvider>
 	): Promise<TFunction<FallbackNs<N>, KPrefix>>;
 	async getFixedT<
 		N extends
@@ -129,12 +131,13 @@ export class RemixI18Next {
 		requestOrLocale: Request | string,
 		namespaces?: N,
 		options: Omit<InitOptions, "react"> & { keyPrefix?: KPrefix } = {},
+        context?: Readonly<RouterContextProvider>
 	): Promise<TFunction<FallbackNs<N>, KPrefix>> {
 		let [instance, locale] = await Promise.all([
 			this.createInstance({ ...this.options.i18next, ...options }),
 			typeof requestOrLocale === "string"
 				? requestOrLocale
-				: this.getLocale(requestOrLocale),
+				: this.getLocale(requestOrLocale, context),
 		]);
 
 		await instance.changeLanguage(locale);


### PR DESCRIPTION
Allowing custom logic in findLocale to make use of the context object.

Use case: previous middleware retrieves user preference from DB for logged in users, which includes language, and stores it in context.
Within the findLocale function want to first check if user preference is in context and take language from there if it is, otherwise get language from cookie/session/etc.
Currently forced to duplicate the potentially expensive retrieval of user preference from DB within findLocale since there's no access to the context.

getFixedT function needs to be updated as well to accept the context - only need to provide it if you've defined a findLocale function that makes use of it
