### PR TITLE
Add Locize integration example to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -603,4 +603,4 @@ Without this route, any not found request will not run the middleware in root, c
 
 ## Related examples
 
-- [locize/locize-react-router-example](https://github.com/locize/locize-react-router-example) — remix-i18next with a translation management backend: SSR-bundled translations via [`locize-cli`](https://github.com/locize/locize-cli), client-side CDN fetch + `saveMissing` via [`i18next-locize-backend`](https://github.com/locize/i18next-locize-backend), and the Locize InContext editor wired through `locizePlugin`. Walkthrough: [Adding Locize to your React Router + remix-i18next app](https://www.locize.com/blog/react-router-i18next).
+- [with Locize](https://github.com/locize/locize-react-router-example) - Use remix-i18next with Locize as backend.

--- a/README.md
+++ b/README.md
@@ -600,3 +600,7 @@ export default function Component() {
 If you're using `@react-router/fs-routes` package, you can create a file named `app/routes/$.tsx` and it will be used automatically. If you're configuring your routes manually, create a file `app/routes/not-found.tsx` and add `route("*", "./routes/not-found.tsx")` to your routes configuration.
 
 Without this route, any not found request will not run the middleware in root, causing `entry.server.tsx` to not have the i18next instance configured, resulting in an error.
+
+## Related examples
+
+- [locize/locize-react-router-example](https://github.com/locize/locize-react-router-example) — remix-i18next with a translation management backend: SSR-bundled translations via [`locize-cli`](https://github.com/locize/locize-cli), client-side CDN fetch + `saveMissing` via [`i18next-locize-backend`](https://github.com/locize/i18next-locize-backend), and the Locize InContext editor wired through `locizePlugin`. Walkthrough: [Adding Locize to your React Router + remix-i18next app](https://www.locize.com/blog/react-router-i18next).


### PR DESCRIPTION
## Summary

Adds a short **Related examples** section at the end of the README pointing to a community example that pairs remix-i18next with the Locize translation management backend. The setup is built on top of the README's existing middleware-based flow — it doesn't reimplement or fork it, just layers on:

- SSR-bundled translations synced at build time via [`locize-cli`](https://github.com/locize/locize-cli)
- Client-side CDN fetch + `saveMissing` via [`i18next-locize-backend`](https://github.com/locize/i18next-locize-backend)
- The Locize InContext editor wired through `locizePlugin`

There's also a walkthrough post that may help readers who want to follow a step-by-step setup: https://www.locize.com/blog/react-router-i18next

If this is more useful as a separate `EXAMPLES.md` instead of inline at the end of the README, happy to move it — let me know.

## Test plan

- [x] README renders correctly (links resolve, markdown is well-formed)
- [x] No code or peer-dep changes — README-only addition