### PR TITLE
Made field `supportedLanguages` readonly 

### DIFF
--- a/src/lib/language-detector.ts
+++ b/src/lib/language-detector.ts
@@ -13,7 +13,7 @@ export interface LanguageDetectorOption {
 	 * the languages requested by the user is supported by the application.
 	 * This should be be same as the supportedLngs in the i18next options.
 	 */
-	supportedLanguages: string[];
+	supportedLanguages: readonly string[];
 	/**
 	 * Define the fallback language that it's going to be used in the case user
 	 * expected language is not supported.


### PR DESCRIPTION
This change allows narrower typing and should be fully backwards compatible. 
`supportedLngs` in the i18next repo does also support `readonly string[]` :) 

In most projects I've used remix-i18next with, the language array was declared as a readonly constant. 
However, the language detector does not accept that readonly string[], therefore there were always some typescript shenanigans needed to put that array into the language detector. Since the detector isn't messing with the array itself and the pick() method also accepts readonly strings, I thought this might be a useful addition. If not, thats also ok ^^ 